### PR TITLE
feat(landing): one-click downloads for the visitor's OS

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,6 +3,7 @@
     "**/dist/**",
     "**/src-tauri/**",
     "apps/landing/public/demo/**",
-    "pnpm-lock.yaml"
+    "pnpm-lock.yaml",
+    "CHANGELOG.md"
   ]
 }

--- a/apps/landing/src/app.tsx
+++ b/apps/landing/src/app.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import type { ReactNode } from "react";
+import { GITHUB, RELEASES, useDownloads } from "./downloads";
+import type { Cta } from "./downloads";
 import { LogoMark, Wordmark } from "./logo";
 
-const GITHUB = "https://github.com/joshxfi/noteside";
-const RELEASES = `${GITHUB}/releases`;
 const AUTHOR = "https://github.com/joshxfi";
+
+// Direct file downloads save in place; page links open in a new tab.
+const linkProps = (c: Cta) =>
+  c.download ? { rel: "noopener" } : { target: "_blank", rel: "noopener noreferrer" };
 // The docs site (docs.noteside.app in prod). Override with VITE_DOCS_URL — e.g.
 // http://localhost:3002 when running `pnpm dev:docs` locally.
 const DOCS = import.meta.env.VITE_DOCS_URL ?? "https://docs.noteside.app";
@@ -161,6 +165,7 @@ const sectionH2 =
 
 export function App() {
   const step = useKeycast();
+  const dl = useDownloads();
   useScrollReveal();
 
   return (
@@ -219,13 +224,8 @@ export function App() {
             everyday shortcuts you already know.
           </p>
           <div className="mt-[34px] mb-3.5 flex flex-wrap justify-center gap-3" id="get">
-            <a
-              className="btn btn-primary"
-              href={`${RELEASES}/latest`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Download for desktop
+            <a className="btn btn-primary" href={dl.primary.href} {...linkProps(dl.primary)}>
+              {dl.primary.label}
             </a>
             <a className="btn btn-ghost" href="#demo">
               Try the live demo
@@ -234,7 +234,25 @@ export function App() {
           <p className="font-mono text-[12.5px] text-ink-faint">
             Free forever · open source ·{" "}
             <b className="font-semibold text-ink-soft">macOS, Windows &amp; Linux</b>
+            {dl.version ? <> · {dl.version}</> : null}
           </p>
+          {(dl.primary.note || dl.alternates.length > 0) && (
+            <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 font-mono text-[12.5px] text-ink-faint">
+              {dl.primary.note ? <span className="text-ink-soft">{dl.primary.note}</span> : null}
+              {dl.alternates.map((alt, i) => (
+                <Fragment key={alt.label}>
+                  {i > 0 || dl.primary.note ? <span aria-hidden="true">·</span> : null}
+                  <a
+                    className="inline-block py-0.5 text-ink-soft underline underline-offset-2 hover:text-accent"
+                    href={alt.href}
+                    {...linkProps(alt)}
+                  >
+                    {alt.label}
+                  </a>
+                </Fragment>
+              ))}
+            </p>
+          )}
         </section>
 
         <section className="pt-10 pb-24" id="demo">

--- a/apps/landing/src/downloads.ts
+++ b/apps/landing/src/downloads.ts
@@ -1,0 +1,263 @@
+// downloads.ts — turn the latest GitHub release into one obvious download for
+// the visitor's OS, so non-technical users never face the wall of installer
+// filenames on the Releases page. Pure helpers (OS/arch detection, asset
+// matching) are unit-friendly; `useDownloads()` fetches the release client-side
+// (always current, independent of when the landing redeploys) and degrades to
+// the Releases page if the request fails or the OS is unknown.
+import { useEffect, useState } from "react";
+
+export const GITHUB = "https://github.com/joshxfi/noteside";
+export const RELEASES = `${GITHUB}/releases`;
+const LATEST_PAGE = `${RELEASES}/latest`;
+const LATEST_API = "https://api.github.com/repos/joshxfi/noteside/releases/latest";
+const CACHE_KEY = "noteside:latest-release";
+
+export type OS = "mac" | "windows" | "linux" | null;
+export type MacArch = "arm" | "x64" | "unknown";
+
+export interface ReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+export interface Release {
+  tag_name: string;
+  assets: ReleaseAsset[];
+}
+
+export interface Cta {
+  label: string;
+  href: string;
+  note?: string;
+  // A direct file download (browser saves it) vs. a page to open in a new tab.
+  download: boolean;
+}
+
+export interface Downloads {
+  primary: Cta;
+  alternates: Cta[];
+  version: string | null;
+}
+
+// --- platform detection (browser-only; callers pass navigator fields in) ---
+
+interface NavInfo {
+  ua: string;
+  platform: string;
+  uaDataPlatform?: string;
+  maxTouchPoints?: number;
+}
+
+export function detectOS({ ua, platform, uaDataPlatform, maxTouchPoints = 0 }: NavInfo): OS {
+  const s = `${uaDataPlatform ?? ""} ${platform} ${ua}`.toLowerCase();
+  // Mobile has no desktop build — show the generic picker instead of a wrong file.
+  if (/android/.test(s)) return null;
+  if (/iphone|ipad|ipod/.test(s)) return null;
+  const looksMac = /mac/.test(s);
+  // iPadOS in desktop mode reports as "Macintosh" but exposes touch points.
+  if (looksMac && maxTouchPoints > 1) return null;
+  if (looksMac) return "mac";
+  if (/win/.test(s)) return "windows";
+  if (/linux|x11|cros/.test(s)) return "linux";
+  return null;
+}
+
+function currentOS(): OS {
+  if (typeof navigator === "undefined") return null;
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  return detectOS({
+    ua: navigator.userAgent,
+    platform: navigator.platform ?? "",
+    uaDataPlatform: uaData?.platform,
+    maxTouchPoints: navigator.maxTouchPoints,
+  });
+}
+
+// Best-effort CPU arch for macOS — Chromium exposes it via UA-CH; Safari does
+// not, so we return "unknown" and default the UI to Apple Silicon.
+async function detectMacArch(): Promise<MacArch> {
+  try {
+    const uaData = (
+      navigator as Navigator & {
+        userAgentData?: {
+          getHighEntropyValues?: (h: string[]) => Promise<{ architecture?: string }>;
+        };
+      }
+    ).userAgentData;
+    if (uaData?.getHighEntropyValues) {
+      const { architecture } = await uaData.getHighEntropyValues(["architecture"]);
+      if (architecture === "arm") return "arm";
+      if (architecture === "x86") return "x64";
+    }
+  } catch {
+    /* fall through to unknown */
+  }
+  return "unknown";
+}
+
+// --- asset matching (version-independent: classify by extension + arch) ---
+
+type Kind = "macArm" | "macX64" | "winExe" | "winMsi" | "linuxAppImage" | "linuxDeb" | "linuxRpm";
+
+function classify(name: string): Kind | null {
+  const n = name.toLowerCase();
+  if (n.endsWith(".dmg")) {
+    if (/aarch64|arm64/.test(n)) return "macArm";
+    return "macX64"; // x64 / x86_64 / intel, or an unsuffixed single dmg
+  }
+  if (n.endsWith(".msi")) return "winMsi";
+  if (n.endsWith(".exe")) return "winExe";
+  if (n.endsWith(".appimage")) return "linuxAppImage";
+  if (n.endsWith(".deb")) return "linuxDeb";
+  if (n.endsWith(".rpm")) return "linuxRpm";
+  return null; // .app.tar.gz, .sig, checksums — not end-user installers
+}
+
+function indexAssets(assets: ReleaseAsset[]): Partial<Record<Kind, string>> {
+  const out: Partial<Record<Kind, string>> = {};
+  for (const a of assets) {
+    const k = classify(a.name);
+    if (k && !out[k]) out[k] = a.browser_download_url;
+  }
+  return out;
+}
+
+export function buildDownloads(os: OS, macArch: MacArch, release: Release | null): Downloads {
+  const version = release?.tag_name ?? null;
+  const a = release ? indexAssets(release.assets) : {};
+  const file = (href: string, label: string, note?: string): Cta => ({
+    label,
+    href,
+    note,
+    download: true,
+  });
+  // A labelled button pointing at the Releases page — used both as a real
+  // new-tab link and as the transient target for a known OS before the release
+  // loads, so the button always shows the right OS label from first paint.
+  const page = (label: string): Cta => ({ label, href: LATEST_PAGE, download: false });
+  const allDownloads = page("All downloads ↗");
+
+  if (os === "mac") {
+    const intel = macArch === "x64";
+    const primaryUrl = intel ? (a.macX64 ?? a.macArm) : (a.macArm ?? a.macX64);
+    if (!primaryUrl)
+      return { version, primary: page("Download for macOS"), alternates: [allDownloads] };
+    const note = primaryUrl === a.macArm ? "Apple Silicon" : "Intel";
+    const otherUrl = primaryUrl === a.macArm ? a.macX64 : a.macArm;
+    const otherLabel = primaryUrl === a.macArm ? "Intel Mac" : "Apple Silicon";
+    return {
+      version,
+      primary: file(primaryUrl, "Download for macOS", note),
+      alternates: [...(otherUrl ? [file(otherUrl, otherLabel)] : []), allDownloads],
+    };
+  }
+
+  if (os === "windows") {
+    const primaryUrl = a.winExe ?? a.winMsi;
+    if (!primaryUrl)
+      return { version, primary: page("Download for Windows"), alternates: [allDownloads] };
+    return {
+      version,
+      primary: file(primaryUrl, "Download for Windows"),
+      alternates: [
+        ...(a.winExe && a.winMsi ? [file(a.winMsi, ".msi installer")] : []),
+        allDownloads,
+      ],
+    };
+  }
+
+  if (os === "linux") {
+    const primaryUrl = a.linuxAppImage ?? a.linuxDeb ?? a.linuxRpm;
+    if (!primaryUrl)
+      return { version, primary: page("Download for Linux"), alternates: [allDownloads] };
+    const note =
+      primaryUrl === a.linuxAppImage ? "AppImage" : primaryUrl === a.linuxDeb ? ".deb" : ".rpm";
+    const alternates: Cta[] = [];
+    for (const [url, label] of [
+      [a.linuxAppImage, "AppImage"],
+      [a.linuxDeb, ".deb"],
+      [a.linuxRpm, ".rpm"],
+    ] as const) {
+      if (url && url !== primaryUrl) alternates.push(file(url, label));
+    }
+    return {
+      version,
+      primary: file(primaryUrl, "Download for Linux", note),
+      alternates: [...alternates, allDownloads],
+    };
+  }
+
+  // Genuinely unknown OS (mobile, unrecognised UA) → a generic button to the
+  // Releases page, plus one direct link per platform once assets are known.
+  const alternates: Cta[] = [];
+  const mac = a.macArm ?? a.macX64;
+  const win = a.winExe ?? a.winMsi;
+  const linux = a.linuxAppImage ?? a.linuxDeb ?? a.linuxRpm;
+  if (mac) alternates.push(file(mac, "macOS"));
+  if (win) alternates.push(file(win, "Windows"));
+  if (linux) alternates.push(file(linux, "Linux"));
+  return { version, primary: page("Download for desktop"), alternates };
+}
+
+// --- caching: one API call per session, refreshed in the background ---
+
+function readCache(): Release | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    // Validate the same way the network response is — a stale/foreign cache
+    // shape would otherwise reach indexAssets and throw during render.
+    const data = JSON.parse(raw);
+    return data && Array.isArray(data.assets) ? (data as Release) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(release: Release) {
+  try {
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(release));
+  } catch {
+    /* private mode / quota — fine, we just refetch next time */
+  }
+}
+
+export function useDownloads(): Downloads {
+  const [os] = useState<OS>(currentOS);
+  const [macArch, setMacArch] = useState<MacArch>("unknown");
+  const [release, setRelease] = useState<Release | null>(readCache);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (os === "mac") {
+      void detectMacArch().then((arch) => {
+        if (!cancelled) setMacArch(arch);
+      });
+    }
+
+    fetch(LATEST_API, { headers: { Accept: "application/vnd.github+json" } })
+      .then((r) => (r.ok ? (r.json() as Promise<Release>) : null))
+      .then((data) => {
+        if (cancelled || !data || !Array.isArray(data.assets)) return;
+        // Keep only the fields we use, so the cache stays small.
+        const slim: Release = {
+          tag_name: data.tag_name,
+          assets: data.assets.map((x) => ({
+            name: x.name,
+            browser_download_url: x.browser_download_url,
+          })),
+        };
+        setRelease(slim);
+        writeCache(slim);
+      })
+      .catch(() => {
+        /* offline / rate-limited → the UI keeps the Releases-page fallback */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [os]);
+
+  return buildDownloads(os, macArch, release);
+}


### PR DESCRIPTION
## What & why

Now that v1.0.0 is published, non-technical visitors who click "download" land on the GitHub Releases page and face a wall of installer filenames (`.dmg` / `.msi` / `.AppImage` / `.deb` / `.rpm`, plus `.app.tar.gz` updater artifacts and checksums). This adds an **OS-aware download** to the landing hero so they get one obvious button for their platform.

## How it works

New module **`apps/landing/src/downloads.ts`** — pure helpers + a `useDownloads()` hook:

- `detectOS()` + best-effort macOS arch detection (Apple Silicon default, Intel alternate; via UA-CH on Chromium, degrades gracefully on Safari).
- `buildDownloads()` matches release assets by **extension + arch** — version-independent, and skips the `.app.tar.gz` updater artifacts — exposing a per-OS primary button plus alternates.
- The release is fetched **client-side from the GitHub API**, so the links stay current regardless of when the landing redeploys. Cached per session; **degrades to the Releases page** when offline, rate-limited, or the OS is unknown (mobile / unrecognised UA).
- The hero button shows the right OS label from first paint; the `href` upgrades from the Releases page to the direct file once the release loads — no "wall of files" flash.

## Hardening

Ran an adversarial review across correctness / resilience / UX-a11y / build, and fixed:

- **Cache-shape validation** — a stale or foreign `sessionStorage` value could otherwise reach `indexAssets` and throw during render (blank page, persistent across reloads).
- **OS-labelled button pre-fetch** — known-OS visitors no longer briefly see a generic "Download for desktop → Releases page".
- **Accessible alternate links** — persistent underlines, larger tap targets, non-interactive separators.

## Verification

- `typecheck`, `lint` (oxlint), `format` (oxfmt), and the landing build pass locally — and CI re-runs them here.
- Rendered the built landing headlessly: "Download for macOS" + the live `v1.0.0` tag + "Apple Silicon · Intel Mac · All downloads" all resolve correctly against the real release assets.
- No new dependencies.

> Merging redeploys the landing via Vercel.
