### PR TITLE
docs: explain the macOS "damaged" Gatekeeper warning on first launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ window, with a Rust core that treats your files as the source of truth.
 
 > **Install:** download a build for macOS, Windows, or Linux from
 > [Releases](https://github.com/joshxfi/noteside/releases/latest), or build from
-> source (below). Builds aren't code-signed yet, so the first launch needs a
-> one-time OS confirmation.
+> source (below). Builds aren't code-signed yet — macOS flags them as _"damaged"_
+> on first launch (Gatekeeper blocking an unsigned download, not real damage).
+> [Getting started](https://docs.noteside.app/getting-started) has the one-line
+> fix. Signing is on the roadmap.
 
 ## Highlights
 

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -16,10 +16,22 @@ Releases](https://github.com/joshxfi/noteside/releases/latest):
 - **Linux** — `.AppImage`, `.deb`, or `.rpm`
 
 <Callout title="First launch">
-  The builds aren't code-signed yet, so your OS shows a one-time prompt. On macOS, right-click the
-  app and choose **Open** (or System Settings → Privacy & Security → **Open Anyway**). On Windows,
-  click **More info → Run anyway**. Signing is on the roadmap.
+  The builds aren't code-signed yet, so your OS shows a one-time warning on first launch. The app
+  isn't broken — your system just can't verify an unsigned download. Signing is on the roadmap.
 </Callout>
+
+**macOS** reports the app as _"damaged and can't be opened."_ It isn't damaged — that's Gatekeeper
+refusing an unsigned, quarantined download (more strictly on Apple Silicon). Drag **Noteside** into
+`/Applications`, then clear the quarantine flag:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Noteside.app
+```
+
+It opens normally after that. Right-click → **Open** does _not_ clear the "damaged" message — only
+removing the quarantine flag does.
+
+**Windows** — click **More info → Run anyway** on the SmartScreen prompt.
 
 ## Build from source
 

--- a/apps/landing/src/app.tsx
+++ b/apps/landing/src/app.tsx
@@ -253,6 +253,19 @@ export function App() {
               ))}
             </p>
           )}
+          {dl.os === "mac" && (
+            <p className="mt-2 font-mono text-[12.5px] text-ink-faint">
+              Unsigned build — macOS shows a one-time warning on first launch.{" "}
+              <a
+                className="underline underline-offset-2 hover:text-accent"
+                href={`${DOCS}/getting-started`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                How to open it ↗
+              </a>
+            </p>
+          )}
         </section>
 
         <section className="pt-10 pb-24" id="demo">

--- a/apps/landing/src/downloads.ts
+++ b/apps/landing/src/downloads.ts
@@ -221,7 +221,10 @@ function writeCache(release: Release) {
   }
 }
 
-export function useDownloads(): Downloads {
+// Returns the asset selection plus the detected `os`, so the UI can show
+// OS-specific hints (e.g. the macOS Gatekeeper first-launch note) — including in
+// the no-asset fallback, where `buildDownloads` alone wouldn't reveal the OS.
+export function useDownloads(): Downloads & { os: OS } {
   const [os] = useState<OS>(currentOS);
   const [macArch, setMacArch] = useState<MacArch>("unknown");
   const [release, setRelease] = useState<Release | null>(readCache);
@@ -259,5 +262,5 @@ export function useDownloads(): Downloads {
     };
   }, [os]);
 
-  return buildDownloads(os, macArch, release);
+  return { ...buildDownloads(os, macArch, release), os };
 }


### PR DESCRIPTION
## Why

Downloaded builds are unsigned / un-notarized, so on first launch macOS Gatekeeper reports the app as **"Noteside is damaged and can't be opened. You should move it to the Trash."** (more aggressively on Apple Silicon). The app isn't damaged — that's Gatekeeper refusing an unsigned, quarantined download.

The previous getting-started callout told macOS users to **right-click → Open**, which only clears the milder _"unidentified developer"_ prompt — it does **not** clear _"damaged."_ So anyone hitting this dialog was following advice that can't fix it, and would most likely assume the app is broken and trash it.

## What

- **docs/getting-started** — replace the wrong instructions with the working fix: drag the app into `/Applications`, then `xattr -dr com.apple.quarantine /Applications/Noteside.app`. Explains it's Gatekeeper (not real damage) and notes right-click → Open won't clear "damaged."
- **README** — stop understating it as a generic "one-time OS confirmation"; name the _"damaged"_ message and link to getting-started for the fix.
- **landing** — show a macOS-only first-launch note beside the download CTA (the most likely place a non-technical visitor hits this). `useDownloads()` now exposes the detected `os`, so the hint shows for Mac visitors only — including the no-asset fallback.

## Verification

- Docs build — `/getting-started` prerenders; the fenced code block inside `<Callout>` compiles ✓
- Landing — typecheck ✓ · lint ✓ · format ✓ · `vite build` ✓

## Follow-up (not in scope)

The real cure is **Developer ID signing + notarization** in `release.yml` (needs Apple secrets added to the repo) — that removes the dialog entirely.

Chose `docs:` over `feat:` deliberately — nothing here changes desktop functionality, so it won't trigger a desktop version bump via semantic-release.
