### PR TITLE
chore: add lefthook pre-commit hook to keep commits oxfmt-clean

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,26 @@
+# Git hooks (lefthook). Installed automatically by the root package.json
+# "prepare" script, which runs `lefthook install` after `pnpm install` — so every
+# contributor gets the hooks on clone, no extra setup.
+#
+# pre-commit formats staged files with oxfmt and re-stages the result, so commits
+# are always oxfmt-clean and the CI `format:check` gate can't fail on formatting.
+# CI remains the backstop for anyone who commits with `--no-verify`.
+#
+# Bypass once: `git commit --no-verify` (or `LEFTHOOK=0 git commit …`).
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: oxfmt
+      # oxfmt's supported source types. `exclude` mirrors .oxfmtrc.json's
+      # ignorePatterns so generated/vendored files are never reformatted (dist is
+      # gitignored, but kept here for safety; CHANGELOG.md is generated).
+      glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,json,jsonc,css,md,mdx}"
+      exclude:
+        - "CHANGELOG.md"
+        - "**/dist/**"
+        - "apps/landing/public/demo/**"
+      # `pnpm exec` resolves the workspace-local oxfmt binary cross-platform —
+      # lefthook does not add node_modules/.bin to PATH.
+      run: pnpm exec oxfmt {staged_files}
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "lint:fix": "oxlint --fix",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
+    "prepare": "lefthook install",
     "tauri": "pnpm --filter @noteside/desktop tauri",
     "demo:build": "pnpm --filter @noteside/desktop build:web && rm -rf apps/landing/public/demo && cp -r apps/desktop/dist apps/landing/public/demo",
     "build:landing": "pnpm demo:build && pnpm --filter @noteside/landing build",
     "og:build": "bash apps/desktop/scripts/og-build.sh"
   },
   "devDependencies": {
+    "lefthook": "^2.1.9",
     "oxfmt": "0.54.0",
     "oxlint": "^1.69.0",
     "turbo": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
       oxfmt:
         specifier: 0.54.0
         version: 0.54.0
@@ -2877,6 +2880,60 @@ packages:
 
   launch-editor@2.14.1:
     resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -6342,6 +6399,49 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.4
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,9 +6,11 @@ overrides:
   vite@7>esbuild: 0.28.1
 
 # pnpm 11 gates dependency build scripts; esbuild (Vite's bundler) needs its
-# install script to set up its platform binary.
+# install script to set up its platform binary, and lefthook's postinstall wires
+# up the git-hooks binary used by the `prepare` script (see root package.json).
 allowBuilds:
   esbuild: true
+  lefthook: true
 
 # Supply-chain hardening: refuse dependency versions published less than this
 # many minutes ago — mitigates compromised-then-yanked npm packages. 1440 (1 day)


### PR DESCRIPTION
## Why

CI's `format:check` (oxfmt) can fail on formatting that's easy to miss locally — oxfmt formats **Markdown/MDX**, not just TS/CSS, so a docs edit can pass a partial local check yet fail CI. (That just happened on #2.)

## What

A lefthook **pre-commit** hook that formats staged files with oxfmt and re-stages them, so commits are oxfmt-clean before they reach CI. CI stays the backstop for anyone who uses `--no-verify`.

- `lefthook` devDependency + a `prepare` script (`lefthook install`) → the hook installs automatically on `pnpm install`, no per-contributor setup.
- `lefthook.yml`: pre-commit runs `pnpm exec oxfmt {staged_files}` with `stage_fixed: true`. `pnpm exec` resolves the workspace-local binary cross-platform (lefthook does **not** add `node_modules/.bin` to PATH). The `glob` + `exclude` mirror `.oxfmtrc.json` so generated files (CHANGELOG, dist) are skipped.
- `pnpm-workspace.yaml`: allow lefthook's postinstall through pnpm's build-script gate (same pattern as `esbuild`).

## Verification

- A deliberately misformatted staged file is reformatted **and re-staged** by the hook before commit ✔
- This PR's own commit triggered the hook (oxfmt ran on the staged `package.json`) ✔
- `oxfmt --check` clean across the repo (118 files) ✔

## Notes

- `chore:` — tooling only, so it won't trigger a desktop version bump via semantic-release.
- Bypass once with `git commit --no-verify` (or `LEFTHOOK=0 git commit …`).
