### PR TITLE
feat: first-launch vim vs. plain-keyboard onboarding choice

### DIFF
--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -517,7 +517,7 @@ export function App() {
   const finishOnboarding = (vim: boolean) => {
     setOnboarding(false);
     setCfg((c) => ({ ...c, vimMode: vim }));
-    flash(vim ? "vim mode on" : "plain keyboard mode");
+    flash(vim ? "vim mode on" : "plain keyboard mode on");
     setRefocus((r) => r + 1);
   };
   const toggleNav = () => {

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -10,6 +10,7 @@ import { CommandPalette, type PaletteAction } from "./components/command-palette
 import { Backlinks } from "./components/backlinks";
 import { CommandSearch } from "./components/command-search";
 import { Cheatsheet } from "./components/cheatsheet";
+import { Onboarding } from "./components/onboarding";
 import {
   cheatsheetCommands,
   chordLabel,
@@ -24,6 +25,7 @@ import {
   CONFIG_DEFAULTS,
   type Config,
   fontStack,
+  isFirstLaunch,
   parseConfig,
   serializeConfig,
 } from "./settings";
@@ -346,6 +348,8 @@ export function App() {
   const [refocus, setRefocus] = useState(0);
   const [toast, setToast] = useState<string | null>(null);
   const [backlinks, setBacklinks] = useState<{ title: string; refs: Backlink[] } | null>(null);
+  // first-launch vim / plain-keyboard choice; cleared (and persisted) once picked
+  const [onboarding, setOnboarding] = useState(false);
 
   const configLoaded = useRef(false);
 
@@ -404,15 +408,25 @@ export function App() {
   // boot: load config, then last notebook
   useEffect(() => {
     (async () => {
+      let stored: Partial<Config> | null = null;
       try {
-        const stored = await backend.getConfig();
+        stored = await backend.getConfig();
         if (stored) setCfg((c) => ({ ...c, ...stored }));
       } catch {
         /* defaults */
       }
       configLoaded.current = true;
+      let last: string | null = null;
       try {
-        const last = await backend.getLastNotebook();
+        last = await backend.getLastNotebook();
+      } catch {
+        /* no remembered notebook */
+      }
+      // A brand-new user (no stored config, no notebook) gets the one-time
+      // vim/plain-keyboard choice before anything else. Picking it persists the
+      // config, so the gate never fires again.
+      if (isFirstLaunch(stored, last)) setOnboarding(true);
+      try {
         if (last) await openNotebook(last);
         else setStatus("no-notebook");
       } catch {
@@ -497,6 +511,15 @@ export function App() {
     setRefocus((r) => r + 1);
   };
   const setCfgPatch = (patch: Partial<Config>) => setCfg((c) => ({ ...c, ...patch }));
+
+  // Resolve the first-launch choice: set vim on/off and dismiss the gate. Writing
+  // cfg (configLoaded is true by boot's end) persists it, so it never shows again.
+  const finishOnboarding = (vim: boolean) => {
+    setOnboarding(false);
+    setCfg((c) => ({ ...c, vimMode: vim }));
+    flash(vim ? "vim mode on" : "plain keyboard mode");
+    setRefocus((r) => r + 1);
+  };
   const toggleNav = () => {
     setNavOpen((v) => !v);
     setRefocus((r) => r + 1);
@@ -584,6 +607,7 @@ export function App() {
   // overlay is open so it never steals keys from a panel that owns its own focus.
   useGlobalChords({
     enabled: !(
+      onboarding ||
       finder ||
       paletteOpen ||
       cmdSearchOpen ||
@@ -685,7 +709,9 @@ export function App() {
             />
           )}
           <main className="av-main">
-            {status === "boot" ? (
+            {onboarding ? (
+              <Onboarding onChoose={finishOnboarding} />
+            ) : status === "boot" ? (
               <div className="av-empty">
                 <div className="av-empty-glyph">▌</div>
               </div>

--- a/apps/desktop/src/components/onboarding.tsx
+++ b/apps/desktop/src/components/onboarding.tsx
@@ -1,0 +1,93 @@
+// onboarding.tsx — one-time first-launch choice: vim navigation or plain
+// keyboard. Shown only when `isFirstLaunch` (settings.ts) holds; the moment the
+// user picks, App persists `cfg.vimMode`, so it never appears again. Both modes
+// are first-class — there is no "skip", just two equally valid doors in.
+import { useEffect, useRef, useState } from "react";
+import { chordLabel } from "../editor/commands";
+
+export function Onboarding({ onChoose }: { onChoose: (vim: boolean) => void }) {
+  // Vim is Noteside's identity, so it's the highlighted default for keyboard pickers.
+  const [sel, setSel] = useState<0 | 1>(0); // 0 = vim, 1 = plain keyboard
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const k = e.key;
+    if (k === "ArrowLeft" || k === "h") {
+      e.preventDefault();
+      setSel(0);
+    } else if (k === "ArrowRight" || k === "l") {
+      e.preventDefault();
+      setSel(1);
+    } else if (k === "Enter" || k === " ") {
+      e.preventDefault();
+      onChoose(sel === 0);
+    } else if (k === "v") {
+      e.preventDefault();
+      onChoose(true); // straight to vim
+    } else if (k === "n" || k === "p") {
+      e.preventDefault();
+      onChoose(false); // straight to plain keyboard
+    }
+  };
+
+  return (
+    <div className="av-empty ob" ref={ref} tabIndex={0} onKeyDown={onKeyDown}>
+      <div className="av-mark" aria-label="Noteside">
+        <span className="n">N</span>
+        <span className="cur" />
+      </div>
+      <div className="av-empty-title">How do you want to edit?</div>
+      <div className="av-empty-sub">
+        Noteside is keyboard-first either way. Pick what feels like home — you can change this
+        anytime in Settings.
+      </div>
+      <div className="ob-cards" role="radiogroup" aria-label="Editing mode">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={sel === 0}
+          className={"ob-card" + (sel === 0 ? " is-sel" : "")}
+          onMouseEnter={() => setSel(0)}
+          onClick={() => onChoose(true)}
+        >
+          <span className="ob-card-name">Vim</span>
+          <span className="ob-card-desc">
+            Modal editing — opens in NORMAL mode. <kbd>i</kbd> to insert, <kbd>:w</kbd> to save,{" "}
+            <kbd>hjkl</kbd> to move. Full vim, built in.
+          </span>
+          <span className="ob-card-keys">
+            <kbd>h</kbd>
+            <kbd>j</kbd>
+            <kbd>k</kbd>
+            <kbd>l</kbd>
+          </span>
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={sel === 1}
+          className={"ob-card" + (sel === 1 ? " is-sel" : "")}
+          onMouseEnter={() => setSel(1)}
+          onClick={() => onChoose(false)}
+        >
+          <span className="ob-card-name">Plain keyboard</span>
+          <span className="ob-card-desc">
+            Type like any editor. Familiar chords do everything — find, save, new note, the command
+            palette.
+          </span>
+          <span className="ob-card-keys">
+            <kbd>{chordLabel("Mod-p")}</kbd>
+            <kbd>{chordLabel("Mod-s")}</kbd>
+            <kbd>{chordLabel("Mod-/")}</kbd>
+          </span>
+        </button>
+      </div>
+      <div className="av-empty-keys ob-hint">
+        <kbd>←</kbd> <kbd>→</kbd> choose · <kbd>↵</kbd> confirm · or click
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/onboarding.tsx
+++ b/apps/desktop/src/components/onboarding.tsx
@@ -87,8 +87,7 @@ export function Onboarding({ onChoose }: { onChoose: (vim: boolean) => void }) {
         </button>
       </div>
       <div className="av-empty-keys ob-hint">
-        <kbd>←</kbd> <kbd>→</kbd> move · <kbd>↵</kbd> confirm · <kbd>v</kbd> / <kbd>p</kbd> pick ·
-        or click
+        <kbd>←</kbd> <kbd>→</kbd> move · <kbd>↵</kbd> confirm
       </div>
     </div>
   );

--- a/apps/desktop/src/components/onboarding.tsx
+++ b/apps/desktop/src/components/onboarding.tsx
@@ -6,7 +6,8 @@ import { useEffect, useRef, useState } from "react";
 import { chordLabel } from "../editor/commands";
 
 export function Onboarding({ onChoose }: { onChoose: (vim: boolean) => void }) {
-  // Vim is Noteside's identity, so it's the highlighted default for keyboard pickers.
+  // Vim is Noteside's identity, so it's the default keyboard highlight. `sel` is a
+  // keyboard-only cursor (arrows/h/l); a mouse click picks its card directly.
   const [sel, setSel] = useState<0 | 1>(0); // 0 = vim, 1 = plain keyboard
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -26,10 +27,10 @@ export function Onboarding({ onChoose }: { onChoose: (vim: boolean) => void }) {
       onChoose(sel === 0);
     } else if (k === "v") {
       e.preventDefault();
-      onChoose(true); // straight to vim
-    } else if (k === "n" || k === "p") {
+      onChoose(true); // v → straight to vim
+    } else if (k === "p") {
       e.preventDefault();
-      onChoose(false); // straight to plain keyboard
+      onChoose(false); // p → straight to plain keyboard
     }
   };
 
@@ -48,9 +49,9 @@ export function Onboarding({ onChoose }: { onChoose: (vim: boolean) => void }) {
         <button
           type="button"
           role="radio"
+          tabIndex={-1}
           aria-checked={sel === 0}
           className={"ob-card" + (sel === 0 ? " is-sel" : "")}
-          onMouseEnter={() => setSel(0)}
           onClick={() => onChoose(true)}
         >
           <span className="ob-card-name">Vim</span>
@@ -68,9 +69,9 @@ export function Onboarding({ onChoose }: { onChoose: (vim: boolean) => void }) {
         <button
           type="button"
           role="radio"
+          tabIndex={-1}
           aria-checked={sel === 1}
           className={"ob-card" + (sel === 1 ? " is-sel" : "")}
-          onMouseEnter={() => setSel(1)}
           onClick={() => onChoose(false)}
         >
           <span className="ob-card-name">Plain keyboard</span>
@@ -86,7 +87,8 @@ export function Onboarding({ onChoose }: { onChoose: (vim: boolean) => void }) {
         </button>
       </div>
       <div className="av-empty-keys ob-hint">
-        <kbd>←</kbd> <kbd>→</kbd> choose · <kbd>↵</kbd> confirm · or click
+        <kbd>←</kbd> <kbd>→</kbd> move · <kbd>↵</kbd> confirm · <kbd>v</kbd> / <kbd>p</kbd> pick ·
+        or click
       </div>
     </div>
   );

--- a/apps/desktop/src/settings.test.ts
+++ b/apps/desktop/src/settings.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { type Config, CONFIG_DEFAULTS, parseConfig, serializeConfig } from "./settings";
+import {
+  type Config,
+  CONFIG_DEFAULTS,
+  isFirstLaunch,
+  parseConfig,
+  serializeConfig,
+} from "./settings";
 
 describe("config serialize/parse round-trip", () => {
   it("round-trips the defaults exactly", () => {
@@ -77,5 +83,21 @@ describe("config serialize/parse round-trip", () => {
     const parsed = parseConfig('" a comment\nset bogus = 1\nset theme = dark', CONFIG_DEFAULTS);
     expect(parsed.theme).toBe("dark");
     expect(parsed.accent).toBe(CONFIG_DEFAULTS.accent);
+  });
+});
+
+describe("isFirstLaunch", () => {
+  it("is true only with no stored config and no last notebook", () => {
+    expect(isFirstLaunch(null, null)).toBe(true);
+  });
+
+  it("is false once a config has been stored (choice already made)", () => {
+    expect(isFirstLaunch({ vimMode: false }, null)).toBe(false);
+    expect(isFirstLaunch({}, null)).toBe(false); // an empty object still counts as stored
+  });
+
+  it("is false for an existing user with a remembered notebook", () => {
+    expect(isFirstLaunch(null, "/notes")).toBe(false);
+    expect(isFirstLaunch({ vimMode: true }, "/notes")).toBe(false);
   });
 });

--- a/apps/desktop/src/settings.ts
+++ b/apps/desktop/src/settings.ts
@@ -208,3 +208,14 @@ export function parseConfig(text: string, base: Config): Config {
 }
 
 export const byIdHelper = byId;
+
+/**
+ * First launch = the user has never stored a config *and* has no remembered
+ * notebook. Gates the one-time onboarding choice (vim vs. plain keyboard); once
+ * a choice is made the config is persisted, so `stored` is non-null thereafter
+ * and existing users (who always have a last notebook) never see it.
+ */
+export const isFirstLaunch = (
+  stored: Partial<Config> | null,
+  lastNotebook: string | null,
+): boolean => !stored && !lastNotebook;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -719,6 +719,78 @@ body {
   text-underline-offset: 2px;
 }
 
+/* first-launch onboarding — the one-time vim / plain-keyboard choice */
+.ob {
+  outline: none;
+}
+.ob .av-empty-sub {
+  max-width: 420px;
+}
+.ob-cards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+  margin-top: 8px;
+}
+.ob-card {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  width: 252px;
+  min-height: 152px;
+  padding: 16px 16px 14px;
+  text-align: left;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    box-shadow 0.12s ease,
+    background 0.12s ease;
+}
+.ob-card:hover {
+  border-color: var(--accent);
+}
+.ob-card.is-sel {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent), transparent 93%);
+  box-shadow:
+    inset 0 0 0 1px var(--accent),
+    0 14px 32px -20px rgba(60, 30, 55, 0.3);
+}
+.ob-card-name {
+  font-family: var(--serif);
+  font-size: calc(18px * var(--ui-scale));
+  font-weight: 600;
+  color: var(--ink);
+}
+.ob-card-desc {
+  font-size: calc(12.5px * var(--ui-scale));
+  color: var(--ink-faint);
+  line-height: 1.55;
+}
+.ob-card-keys {
+  display: flex;
+  gap: 5px;
+  margin-top: auto;
+  padding-top: 4px;
+}
+.ob kbd {
+  font-family: var(--mono);
+  font-size: calc(11px * var(--ui-scale));
+  color: var(--ink-soft);
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  box-shadow: 0 1px 0 var(--rule);
+  padding: 1px 6px;
+}
+.ob-hint {
+  margin-top: 18px;
+}
+
 /* toast */
 .av-toast {
   position: absolute;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -777,16 +777,7 @@ body {
   margin-top: auto;
   padding-top: 4px;
 }
-.ob kbd {
-  font-family: var(--mono);
-  font-size: calc(11px * var(--ui-scale));
-  color: var(--ink-soft);
-  background: var(--paper-2);
-  border: 1px solid var(--rule);
-  border-radius: 5px;
-  box-shadow: 0 1px 0 var(--rule);
-  padding: 1px 6px;
-}
+/* the card kbds share the empty-state keycap look — see `.av-empty-keys kbd` */
 .ob-hint {
   margin-top: 18px;
 }
@@ -1824,7 +1815,8 @@ html.tauri .av-window {
   font-size: calc(11.5px * var(--ui-scale));
   color: var(--ink-faint);
 }
-.av-empty-keys kbd {
+.av-empty-keys kbd,
+.ob kbd {
   font-family: var(--mono);
   font-size: calc(11px * var(--ui-scale));
   color: var(--ink-soft);


### PR DESCRIPTION
## What & why

New users now choose **how they edit** before anything else — a one-time first-launch screen offering **Vim** (modal, opens in NORMAL mode) or **plain keyboard** (familiar `⌘`/`Ctrl` chords). Both modes are already first-class in Noteside, but the default was silently Vim; this makes the choice explicit and welcoming for non-vim users without burying it in settings.

The screen appears **once**: picking an option writes `cfg.vimMode`, which persists, so the gate never fires again. Existing users (anyone with a remembered notebook) never see it.

## How it works

- **`settings.ts`** — `isFirstLaunch(stored, lastNotebook)`: a pure, node-tested predicate (`!stored && !lastNotebook`). The remembered-notebook signal is what keeps existing users — even those who never opened Settings — out of the flow.
- **`components/onboarding.tsx`** — the screen, built on the app's design tokens (brand mark, serif heading, accent-ring selection). Keyboard-navigable (`←`/`→`/`h`/`l`, `Enter`, or `v`/`p` to pick directly) and click-to-pick.
- **`app.tsx`** — boot reads the last notebook first, gates onboarding on `isFirstLaunch`, renders it ahead of the notebook picker, and suppresses global chords while it's up. Picking calls `finishOnboarding`, which sets `vimMode` (→ persisted via the existing config effect) and dismisses.

## Commits

1. `feat(desktop): detect a genuine first launch (isFirstLaunch helper)` — predicate + tests
2. `feat(desktop): first-launch vim vs. plain-keyboard onboarding choice` — screen + wiring
3. `polish(desktop): tighten onboarding focus, copy, and CSS` — fixes from the audit below

## Verification

**Live browser runs** (mock backend, simulating each user via `localStorage`):

| Scenario | Result |
|---|---|
| Existing user (config + notebook) | Opens straight to editor, no onboarding |
| Used app, never touched settings (notebook, no config) | Opens to editor, no onboarding |
| Fresh → picks Vim | Persists `vimMode:true`, editor mounts vim-active |
| Fresh → picks Plain | Persists `vimMode:false`, conventional editor |
| Reload after choosing | Onboarding never reappears |
| Narrow window (540px) | Cards wrap/stack cleanly |

**Multi-dimension audit** (regression + UX + a11y, each finding adversarially verified) confirmed 7 refinements, all applied in commit 3:
- Cards are `tabIndex={-1}` so the container is the sole tab stop (SettingsPanel convention) — fixes a Space-key double-toast and a focus-ring decoupled from the selection.
- Dropped the undiscoverable `n` accelerator; surfaced `v`/`p` in the hint legend.
- Removed `onMouseEnter` selection-rewrites so hovering can't change what `Enter` commits.
- Toast copy parallelism (`plain keyboard mode on`).
- Deduped the `.ob kbd` CSS into the canonical `.av-empty-keys kbd` rule.

**Gates:** `typecheck` ✓ · `oxlint` ✓ · `oxfmt --check` ✓ · `83 tests` ✓ (incl. 3 new `isFirstLaunch` cases). Rust untouched.

## Note / open question

The detection (`no config + no notebook`) is also true for the **landing's embedded demo** on first visit, so a demo visitor sees this screen before the "Open a notebook" picker. Left in deliberately (it showcases the dual-mode story), but easy to gate to the real app only (`backend.live`) if you'd prefer the demo stay frictionless.
