### PR TITLE
polish(landing): tidy the hero download CTA, hide demo on mobile

### DIFF
--- a/apps/landing/src/app.tsx
+++ b/apps/landing/src/app.tsx
@@ -227,48 +227,57 @@ export function App() {
             <a className="btn btn-primary" href={dl.primary.href} {...linkProps(dl.primary)}>
               {dl.primary.label}
             </a>
-            <a className="btn btn-ghost" href="#demo">
+            <a className="btn btn-ghost max-sm:hidden" href="#demo">
               Try the live demo
             </a>
           </div>
-          <p className="font-mono text-[12.5px] text-ink-faint">
-            Free forever · open source ·{" "}
-            <b className="font-semibold text-ink-soft">macOS, Windows &amp; Linux</b>
-            {dl.version ? <> · {dl.version}</> : null}
+          <p className="mx-auto flex max-w-[46rem] flex-wrap items-center justify-center gap-x-2 gap-y-1 font-mono text-[12.5px] text-ink-faint">
+            <span>Free forever · open source</span>
+            {dl.platforms.map((p) => (
+              <Fragment key={p.os}>
+                <span aria-hidden="true">·</span>
+                <a
+                  className={
+                    "underline underline-offset-2 hover:text-accent " +
+                    (p.os === dl.os ? "font-semibold text-ink-soft" : "text-ink-soft")
+                  }
+                  href={p.href}
+                  {...linkProps(p)}
+                >
+                  {p.label}
+                </a>
+              </Fragment>
+            ))}
+            {dl.version ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <a
+                  className="underline underline-offset-2 hover:text-accent"
+                  href={dl.allDownloads.href}
+                  title="All downloads"
+                  {...linkProps(dl.allDownloads)}
+                >
+                  {dl.version}
+                </a>
+              </>
+            ) : null}
           </p>
-          {(dl.primary.note || dl.alternates.length > 0) && (
-            <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 font-mono text-[12.5px] text-ink-faint">
-              {dl.primary.note ? <span className="text-ink-soft">{dl.primary.note}</span> : null}
-              {dl.alternates.map((alt, i) => (
-                <Fragment key={alt.label}>
-                  {i > 0 || dl.primary.note ? <span aria-hidden="true">·</span> : null}
-                  <a
-                    className="inline-block py-0.5 text-ink-soft underline underline-offset-2 hover:text-accent"
-                    href={alt.href}
-                    {...linkProps(alt)}
-                  >
-                    {alt.label}
-                  </a>
-                </Fragment>
-              ))}
-            </p>
-          )}
           {dl.os === "mac" && (
-            <p className="mt-2 font-mono text-[12.5px] text-ink-faint">
-              Unsigned build — macOS shows a one-time warning on first launch.{" "}
+            <p className="mx-auto mt-4 max-w-[32rem] font-mono text-[11px] leading-[1.5] text-ink-faint">
+              macOS shows a one-time warning for unsigned apps.{" "}
               <a
-                className="underline underline-offset-2 hover:text-accent"
+                className="whitespace-nowrap underline underline-offset-2 hover:text-accent"
                 href={`${DOCS}/getting-started`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                How to open it ↗
+                How to open ↗
               </a>
             </p>
           )}
         </section>
 
-        <section className="pt-10 pb-24" id="demo">
+        <section className="pt-10 pb-24 max-sm:hidden" id="demo">
           <div className="reveal relative mx-auto aspect-[1120/740] w-[min(1120px,94vw)] overflow-hidden rounded-[18px] border border-rule-soft bg-paper-2 shadow-[var(--shadow)]">
             <iframe
               className="absolute inset-0 block h-full w-full border-0"
@@ -356,7 +365,7 @@ export function App() {
                 <a className="whitespace-nowrap hover:text-accent" href="#get">
                   Get started
                 </a>
-                <a className="whitespace-nowrap hover:text-accent" href="#demo">
+                <a className="whitespace-nowrap hover:text-accent max-sm:hidden" href="#demo">
                   Live demo
                 </a>
                 <a className="whitespace-nowrap hover:text-accent" href="#features">

--- a/apps/landing/src/downloads.ts
+++ b/apps/landing/src/downloads.ts
@@ -32,10 +32,24 @@ export interface Cta {
   download: boolean;
 }
 
+/** One platform's primary download, for the inline "macOS · Windows · Linux"
+ *  links. Shaped to satisfy `Cta` (label/href/download) so `linkProps` works on it,
+ *  plus `os` so the UI can mark the visitor's own platform. */
+export interface PlatformLink {
+  os: "mac" | "windows" | "linux";
+  label: string;
+  href: string;
+  download: boolean;
+}
+
 export interface Downloads {
   primary: Cta;
   alternates: Cta[];
   version: string | null;
+  /** One direct download per platform (most common variant), in mac/windows/linux order. */
+  platforms: PlatformLink[];
+  /** The Releases page ("All downloads ↗") — the escape hatch for other arches/variants. */
+  allDownloads: Cta;
 }
 
 // --- platform detection (browser-only; callers pass navigator fields in) ---
@@ -121,6 +135,25 @@ function indexAssets(assets: ReleaseAsset[]): Partial<Record<Kind, string>> {
   return out;
 }
 
+const PLATFORM_LABEL = { mac: "macOS", windows: "Windows", linux: "Linux" } as const;
+
+// One direct download per platform (the dominant variant) for the inline platform
+// links. Until the release loads — or if a platform's asset is missing — the link
+// points at the Releases page instead, so it's always clickable and never dead.
+function platformLinks(a: Partial<Record<Kind, string>>): PlatformLink[] {
+  const pick = {
+    mac: a.macArm ?? a.macX64,
+    windows: a.winExe ?? a.winMsi,
+    linux: a.linuxAppImage ?? a.linuxDeb ?? a.linuxRpm,
+  };
+  return (["mac", "windows", "linux"] as const).map((os) => ({
+    os,
+    label: PLATFORM_LABEL[os],
+    href: pick[os] ?? LATEST_PAGE,
+    download: !!pick[os],
+  }));
+}
+
 export function buildDownloads(os: OS, macArch: MacArch, release: Release | null): Downloads {
   const version = release?.tag_name ?? null;
   const a = release ? indexAssets(release.assets) : {};
@@ -135,17 +168,20 @@ export function buildDownloads(os: OS, macArch: MacArch, release: Release | null
   // loads, so the button always shows the right OS label from first paint.
   const page = (label: string): Cta => ({ label, href: LATEST_PAGE, download: false });
   const allDownloads = page("All downloads ↗");
+  // Fields common to every branch — the inline platform links, the Releases-page
+  // escape hatch, and the version.
+  const base = { version, platforms: platformLinks(a), allDownloads };
 
   if (os === "mac") {
     const intel = macArch === "x64";
     const primaryUrl = intel ? (a.macX64 ?? a.macArm) : (a.macArm ?? a.macX64);
     if (!primaryUrl)
-      return { version, primary: page("Download for macOS"), alternates: [allDownloads] };
+      return { ...base, primary: page("Download for macOS"), alternates: [allDownloads] };
     const note = primaryUrl === a.macArm ? "Apple Silicon" : "Intel";
     const otherUrl = primaryUrl === a.macArm ? a.macX64 : a.macArm;
     const otherLabel = primaryUrl === a.macArm ? "Intel Mac" : "Apple Silicon";
     return {
-      version,
+      ...base,
       primary: file(primaryUrl, "Download for macOS", note),
       alternates: [...(otherUrl ? [file(otherUrl, otherLabel)] : []), allDownloads],
     };
@@ -154,9 +190,9 @@ export function buildDownloads(os: OS, macArch: MacArch, release: Release | null
   if (os === "windows") {
     const primaryUrl = a.winExe ?? a.winMsi;
     if (!primaryUrl)
-      return { version, primary: page("Download for Windows"), alternates: [allDownloads] };
+      return { ...base, primary: page("Download for Windows"), alternates: [allDownloads] };
     return {
-      version,
+      ...base,
       primary: file(primaryUrl, "Download for Windows"),
       alternates: [
         ...(a.winExe && a.winMsi ? [file(a.winMsi, ".msi installer")] : []),
@@ -168,7 +204,7 @@ export function buildDownloads(os: OS, macArch: MacArch, release: Release | null
   if (os === "linux") {
     const primaryUrl = a.linuxAppImage ?? a.linuxDeb ?? a.linuxRpm;
     if (!primaryUrl)
-      return { version, primary: page("Download for Linux"), alternates: [allDownloads] };
+      return { ...base, primary: page("Download for Linux"), alternates: [allDownloads] };
     const note =
       primaryUrl === a.linuxAppImage ? "AppImage" : primaryUrl === a.linuxDeb ? ".deb" : ".rpm";
     const alternates: Cta[] = [];
@@ -180,22 +216,16 @@ export function buildDownloads(os: OS, macArch: MacArch, release: Release | null
       if (url && url !== primaryUrl) alternates.push(file(url, label));
     }
     return {
-      version,
+      ...base,
       primary: file(primaryUrl, "Download for Linux", note),
       alternates: [...alternates, allDownloads],
     };
   }
 
   // Genuinely unknown OS (mobile, unrecognised UA) → a generic button to the
-  // Releases page, plus one direct link per platform once assets are known.
-  const alternates: Cta[] = [];
-  const mac = a.macArm ?? a.macX64;
-  const win = a.winExe ?? a.winMsi;
-  const linux = a.linuxAppImage ?? a.linuxDeb ?? a.linuxRpm;
-  if (mac) alternates.push(file(mac, "macOS"));
-  if (win) alternates.push(file(win, "Windows"));
-  if (linux) alternates.push(file(linux, "Linux"));
-  return { version, primary: page("Download for desktop"), alternates };
+  // Releases page; the inline platform links (in `base`) still give one direct
+  // download per platform once assets are known.
+  return { ...base, primary: page("Download for desktop"), alternates: [allDownloads] };
 }
 
 // --- caching: one API call per session, refreshed in the background ---


### PR DESCRIPTION
## What & why

The download meta under the hero buttons had grown to **three equal-weight mono lines** with no hierarchy — and the longest, most prose-y line (the macOS Gatekeeper caveat) read as loud as the value props. This tidies the whole cluster and improves the mobile experience.

### Before → after

```
Before (3 lines):
  Free forever · open source · macOS, Windows & Linux · v1.0.0
          Apple Silicon · Intel Mac · All downloads ↗
  Unsigned build — macOS shows a one-time warning on first launch. How to open it ↗

After (2 lines):
  Free forever · open source · macOS · Windows · Linux · v1.0.0
          macOS shows a one-time warning for unsigned apps. How to open ↗
```

## Changes

- **Collapse the two meta rows into one.** `macOS` · `Windows` · `Linux` are now **direct per-platform download links** (a new `platforms` field in `downloads.ts`, always built, falling back to the Releases page until the release loads), with the visitor's detected OS **bolded**. The **version number** now carries the "all downloads" link to the Releases page, replacing the separate `All downloads ↗`.
- **Demote the macOS Gatekeeper note to a footnote** — smaller, detached, and trimmed (`macOS shows a one-time warning for unsigned apps. How to open`) so it reads as fine print rather than a peer of the value props.
- **Hide the live demo on mobile** (`max-sm:`): the demo `<section>`, the hero "Try the live demo" button, and the footer "Live demo" link. A desktop, keyboard-first app in an iframe is a poor phone experience — and because the iframe is `loading="lazy"` + now `display:none` on phones, **it no longer fetches on mobile** (a load-time win). The nav's Demo link was already hidden below this breakpoint, so no anchor dangles.

## Verification

- **Desktop (1200px):** meta line consolidated; all links resolve to real assets (`macOS → aarch64.dmg`, `Windows → x64-setup.exe`, `Linux → amd64.AppImage`, version → `releases/latest`); primary button still arch-correct; demo section + button + nav all still visible.
- **Mobile (390px):** demo section + both links `display:none`, iframe stayed `about:blank` (never fetched), page flows hero → features → keys → footer cleanly; meta line wraps to two centered rows.
- Gates: landing `typecheck` ✓ · `oxlint` ✓ · `oxfmt --check` ✓.

## Tradeoff (intentional)

The explicit "Apple Silicon / Intel Mac" split and Linux `.deb`/`.rpm` / Windows `.msi` variants no longer appear in the hero. They remain reachable via the version → **Releases page** link, and the big "Download for *OS*" button still serves the *detected* user the arch-correct build. Net cleaner for the overwhelming majority.

Separate from the onboarding work in #4 (desktop).
