### PR TITLE
fix(desktop): apply cursor style and blink settings live

### DIFF
--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -733,6 +733,7 @@ export function App() {
                 savedText={s.savedText}
                 vimMode={cfg.vimMode}
                 cursorBlink={cfg.cursorBlink}
+                cursor={cfg.cursor}
                 relativeNumbers={cfg.relativeNumbers}
                 chordOverrides={cfg.chords}
                 preview={previewOn}

--- a/apps/desktop/src/editor/editor.tsx
+++ b/apps/desktop/src/editor/editor.tsx
@@ -42,6 +42,10 @@ const DIRTY_CHECK_DELAY_MS = 220;
 // can be re-applied to the LIVE editor without a remount (CM wires keymaps at
 // mount; a remount would also steal focus from the open shortcut editor).
 const chordKeymap = new Compartment();
+// drawSelection lives in its own Compartment too, so toggling cursor-blink
+// reconfigures the live editor (same no-remount reason). Both CM's bar caret and
+// vim's block cursor read this drawSelection config for their blink rate.
+const selectionComp = new Compartment();
 
 defineExCommands();
 
@@ -53,6 +57,8 @@ export interface EditorProps {
   savedText: string;
   vimMode: boolean;
   cursorBlink: boolean;
+  /** Caret shape for insert / non-vim mode (vim normal mode is always a block). */
+  cursor: "block" | "bar" | "underline";
   relativeNumbers: boolean;
   /** Non-vim chord overrides (`bind` lines), applied to the chord keymap at mount. */
   chordOverrides?: ChordOverrides;
@@ -201,7 +207,7 @@ export function Editor(props: EditorProps) {
       lineNumbers(relativeNumbers ? { formatNumber: relFmt } : undefined),
       activeLineHighlight,
       highlightActiveLineGutter(),
-      drawSelection(cursorBlink === false ? { cursorBlinkRate: 0 } : {}),
+      selectionComp.of(drawSelection(cursorBlink === false ? { cursorBlinkRate: 0 } : {})),
       history(),
       // in-note find (Mod-f via the command table); matches reuse the .cm-searchMatch
       // theme styling. The default panel handles type / Enter (next) / Esc (close).
@@ -309,6 +315,17 @@ export function Editor(props: EditorProps) {
     });
   }, [props.chordOverrides]);
 
+  // Re-apply cursor-blink to the live editor (no remount → no focus theft).
+  // Reconfiguring the facet makes both CM's cursorLayer and vim's block-cursor
+  // plugin re-read the blink rate, so the change takes effect immediately.
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: selectionComp.reconfigure(
+        drawSelection(props.cursorBlink === false ? { cursorBlinkRate: 0 } : {}),
+      ),
+    });
+  }, [props.cursorBlink]);
+
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
@@ -319,7 +336,7 @@ export function Editor(props: EditorProps) {
   }, [props.savedText]);
 
   return (
-    <div className="av-editor">
+    <div className="av-editor" data-cursor={props.cursor}>
       <div className="av-cm" ref={hostRef} />
       <div className="av-status">
         <div className={"av-mode " + (vimMode ? "mode-" + mode : "mode-text")}>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -809,25 +809,6 @@ body {
   }
 }
 
-/* ── cursor styles ────────────────────────────────────────── */
-.av-editor.cs-bar .av-cursor {
-  background: transparent;
-  color: inherit;
-  border-radius: 0;
-  box-shadow: inset 2px 0 0 var(--accent);
-}
-.av-editor.cs-underline .av-cursor {
-  background: transparent;
-  color: inherit;
-  border-radius: 0;
-  box-shadow: inset 0 -2px 0 var(--accent);
-}
-.av-editor.no-blink .av-cursor,
-.av-editor.no-blink .av-caret {
-  animation: none;
-  opacity: 1;
-}
-
 /* ── settings panel ───────────────────────────────────────── */
 .set-scrim {
   position: absolute;
@@ -1446,6 +1427,26 @@ html.tauri .av-window {
 }
 .av-cm .cm-cursor {
   border-left-color: var(--accent);
+}
+/* Caret shape from cfg.cursor (data-cursor on .av-editor). Scoped with
+   :not(.cm-fat-cursor) so vim's intrinsic normal/visual block stays a block —
+   this governs the insert-mode and non-vim caret only. */
+.av-editor[data-cursor="bar"] .cm-cursor:not(.cm-fat-cursor) {
+  border-left: 2px solid var(--accent);
+  border-bottom: none;
+  background: transparent;
+}
+.av-editor[data-cursor="underline"] .cm-cursor:not(.cm-fat-cursor) {
+  border-left: none;
+  border-bottom: 2px solid var(--accent);
+  background: transparent;
+  width: 0.55em;
+}
+.av-editor[data-cursor="block"] .cm-cursor:not(.cm-fat-cursor) {
+  border-left: none;
+  border-bottom: none;
+  background: color-mix(in oklab, var(--accent), transparent 55%);
+  width: 0.55em;
 }
 
 /* ── legibility: bump the smallest UI fonts (settings panel, status, meta) ── */


### PR DESCRIPTION
Fixes two bugs where the cursor **style** and **blink** settings had no effect — changing them kept a blinking block.

## Root causes

- **Style (block/bar/underline): never wired.** `cfg.cursor` was written by Settings but read by nothing — not passed to `<Editor>`, no CSS hook. The only shape CSS targeted dead `.av-editor.cs-*` / `.av-cursor` selectors left over from the removed bespoke editor (they never match CM6's real `.cm-cursor`).
- **Blink (on/off): applied only at mount.** `drawSelection({ cursorBlinkRate: 0 })` was the correct mechanism but was frozen in the empty-dep mount effect, and `cursorBlink` wasn't in the editor remount key — so toggling never reached the live editor.

## Fix

- Wire `cfg.cursor` → `cursor` prop → `data-cursor` on `.av-editor`; add `[data-cursor] .cm-cursor:not(.cm-fat-cursor)` shape rules. The `:not(.cm-fat-cursor)` keeps vim's intrinsic normal/visual block. Deleted the dead CSS.
- Wrap `drawSelection` in a `Compartment` + a `[props.cursorBlink]` reconfigure effect (same pattern as the existing `chordKeymap`), so blink applies live with no remount / focus theft.

## Verified (driven in a real browser)

- `data-cursor` wired (default `block`); `.cm-cursor` reshapes across bar / underline / block.
- Toggling Blink flips the cursor layer's `animation-duration` **1200ms ↔ 0ms** live.
- **Caveat (by design):** vim normal/visual mode is always a block (plugin behavior), so `cfg.cursor` governs the insert-mode and non-vim caret.

Gate green: `tsc`, vitest (83), `oxlint`, `oxfmt`, `vite build`.
