### PR TITLE
feat(landing): add changelog page

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-router": "1.170.16",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/apps/landing/public/sitemap.xml
+++ b/apps/landing/public/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://noteside.app/changelog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/apps/landing/src/app.tsx
+++ b/apps/landing/src/app.tsx
@@ -1,17 +1,14 @@
 import { Fragment, useEffect, useState } from "react";
 import type { ReactNode } from "react";
-import { GITHUB, RELEASES, useDownloads } from "./downloads";
+import { useDownloads } from "./downloads";
 import type { Cta } from "./downloads";
-import { LogoMark, Wordmark } from "./logo";
-
-const AUTHOR = "https://github.com/joshxfi";
+import { LogoMark } from "./logo";
+import { DOCS, SiteFooter, SiteHeader } from "./chrome";
+import { useHead } from "./head";
 
 // Direct file downloads save in place; page links open in a new tab.
 const linkProps = (c: Cta) =>
   c.download ? { rel: "noopener" } : { target: "_blank", rel: "noopener noreferrer" };
-// The docs site (docs.noteside.app in prod). Override with VITE_DOCS_URL — e.g.
-// http://localhost:3002 when running `pnpm dev:docs` locally.
-const DOCS = import.meta.env.VITE_DOCS_URL ?? "https://docs.noteside.app";
 
 // The live demo embeds the desktop app's web build. In dev, point at the
 // desktop Vite server (started by `turbo dev`); in prod, at /demo, populated by
@@ -164,52 +161,14 @@ const sectionH2 =
   "font-serif font-medium text-[clamp(1.9rem,4vw,2.9rem)] tracking-[-0.02em] max-w-[20ch] mx-auto leading-[1.08] text-balance";
 
 export function App() {
+  useHead("Noteside — notes for keyboard people", "https://noteside.app/");
   const step = useKeycast();
   const dl = useDownloads();
   useScrollReveal();
 
   return (
     <>
-      <header className="sticky top-0 z-20 border-b border-rule-soft bg-paper/88 backdrop-blur-[10px]">
-        <div className="wrap flex h-[62px] items-center gap-[22px]">
-          <a
-            className="inline-block whitespace-nowrap font-serif text-[22px] font-semibold tracking-[-0.01em]"
-            href="#top"
-          >
-            <Wordmark />
-          </a>
-          <nav className="ml-3.5 flex gap-[22px] font-mono text-[13px] text-ink-soft max-sm:hidden">
-            <a className="whitespace-nowrap hover:text-ink" href="#features">
-              Features
-            </a>
-            <a className="whitespace-nowrap hover:text-ink" href="#demo">
-              Demo
-            </a>
-            <a className="whitespace-nowrap hover:text-ink" href="#keys">
-              Keys
-            </a>
-            <a className="whitespace-nowrap hover:text-ink" href={DOCS}>
-              Docs
-            </a>
-            <a
-              className="whitespace-nowrap hover:text-ink"
-              href={GITHUB}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub ↗
-            </a>
-          </nav>
-          <div className="ml-auto flex items-center gap-3">
-            <a className="btn btn-ghost" href={DOCS}>
-              Documentation
-            </a>
-            <a className="btn btn-primary" href="#get">
-              Get started
-            </a>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       <main id="top">
         <section className="wrap pt-[92px] pb-10 text-center max-sm:pt-16 max-sm:pb-[30px]">
@@ -345,81 +304,7 @@ export function App() {
         </section>
       </main>
 
-      <footer className="border-t border-rule-soft bg-paper-2 pt-[54px] pb-[60px]">
-        <div className="wrap">
-          <div className="flex flex-wrap items-start justify-between gap-7">
-            <div className="flex flex-col gap-1 font-serif text-2xl font-semibold">
-              <Wordmark />
-              <span className="font-mono text-[11px] font-normal tracking-[0.03em] text-ink-faint">
-                notes for keyboard people
-              </span>
-            </div>
-            <div className="flex gap-[30px] font-mono text-[13px] text-ink-soft">
-              <div className="flex flex-col gap-2.5">
-                <span className="text-[11px] tracking-[0.12em] uppercase whitespace-nowrap text-ink-faint">
-                  Product
-                </span>
-                <a className="whitespace-nowrap hover:text-accent" href={DOCS}>
-                  Documentation
-                </a>
-                <a className="whitespace-nowrap hover:text-accent" href="#get">
-                  Get started
-                </a>
-                <a className="whitespace-nowrap hover:text-accent max-sm:hidden" href="#demo">
-                  Live demo
-                </a>
-                <a className="whitespace-nowrap hover:text-accent" href="#features">
-                  Features
-                </a>
-              </div>
-              <div className="flex flex-col gap-2.5">
-                <span className="text-[11px] tracking-[0.12em] uppercase whitespace-nowrap text-ink-faint">
-                  Open source
-                </span>
-                <a
-                  className="whitespace-nowrap hover:text-accent"
-                  href={GITHUB}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  GitHub
-                </a>
-                <a
-                  className="whitespace-nowrap hover:text-accent"
-                  href={RELEASES}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Releases
-                </a>
-                <a
-                  className="whitespace-nowrap hover:text-accent"
-                  href={`${GITHUB}/issues`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Issues
-                </a>
-              </div>
-            </div>
-          </div>
-          <div className="mt-[30px] flex w-full flex-wrap justify-between gap-4 border-t border-rule-soft pt-[22px] font-mono text-[12px] text-ink-faint">
-            <span>
-              Free forever. Open source. Built by{" "}
-              <a
-                className="text-ink-soft hover:text-accent"
-                href={AUTHOR}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Josh Daniel
-              </a>
-              .
-            </span>
-            <span>~/.notesiderc</span>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </>
   );
 }

--- a/apps/landing/src/changelog.ts
+++ b/apps/landing/src/changelog.ts
@@ -1,0 +1,133 @@
+// changelog.ts — the /changelog page's data. Fetches every GitHub release
+// client-side (always current, independent of when the landing redeploys) and
+// parses semantic-release's notes into sections. Mirrors downloads.ts's
+// fetch + sessionStorage-cache + graceful-fallback pattern.
+import { useEffect, useState } from "react";
+import { RELEASES } from "./downloads";
+
+export { RELEASES };
+
+const RELEASES_API = "https://api.github.com/repos/joshxfi/noteside/releases";
+const CACHE_KEY = "noteside:releases";
+// The initial release is the full first-version feature dump — too long to be
+// useful here, so it's hidden from the changelog list.
+const HIDDEN_TAGS = new Set(["v1.0.0"]);
+
+interface RawRelease {
+  tag_name: string;
+  name: string | null;
+  published_at: string | null;
+  html_url: string;
+  body: string | null;
+}
+
+export interface ChangeItem {
+  scope: string | null;
+  text: string;
+  commit: { hash: string; url: string } | null;
+}
+export interface Section {
+  title: string;
+  items: ChangeItem[];
+}
+export interface ChangelogEntry {
+  version: string; // tag_name, e.g. "v1.2.0"
+  date: string | null; // published_at (ISO)
+  url: string; // the release's html_url
+  sections: Section[];
+}
+
+export type ChangelogStatus = "loading" | "ready" | "error";
+
+// `* **scope:** text ([hash](url))` — scope + commit link are both optional.
+const BULLET = /^\*\s+(?:\*\*(.+?):\*\*\s+)?(.+?)(?:\s+\(\[([0-9a-f]+)\]\((.+?)\)\))?$/;
+
+/** Parse a semantic-release release body into sections. The leading
+ *  `## [x](…) (date)` line is ignored (version/date come from structured
+ *  fields); each `### Section` collects its `* bullet` items. Pure. */
+export function parseReleaseBody(body: string): Section[] {
+  const sections: Section[] = [];
+  let current: Section | null = null;
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("### ")) {
+      current = { title: line.slice(4).trim(), items: [] };
+      sections.push(current);
+    } else if (current && line.startsWith("* ")) {
+      const m = BULLET.exec(line);
+      if (m) {
+        current.items.push({
+          scope: m[1] ?? null,
+          text: m[2].trim(),
+          commit: m[3] && m[4] ? { hash: m[3], url: m[4] } : null,
+        });
+      }
+    }
+  }
+  return sections;
+}
+
+function toEntries(raw: RawRelease[]): ChangelogEntry[] {
+  return raw
+    .filter((r) => !HIDDEN_TAGS.has(r.tag_name))
+    .map((r) => ({
+      version: r.tag_name,
+      date: r.published_at,
+      url: r.html_url,
+      sections: parseReleaseBody(r.body ?? ""),
+    }));
+}
+
+function readCache(): RawRelease[] | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    return Array.isArray(data) ? (data as RawRelease[]) : null;
+  } catch {
+    return null;
+  }
+}
+function writeCache(releases: RawRelease[]) {
+  try {
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(releases));
+  } catch {
+    /* private mode / quota — we just refetch next time */
+  }
+}
+
+export function useChangelog(): { entries: ChangelogEntry[]; status: ChangelogStatus } {
+  const [raw, setRaw] = useState<RawRelease[] | null>(readCache);
+  const [status, setStatus] = useState<ChangelogStatus>(raw ? "ready" : "loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(RELEASES_API, { headers: { Accept: "application/vnd.github+json" } })
+      .then((r) => (r.ok ? (r.json() as Promise<RawRelease[]>) : null))
+      .then((data) => {
+        if (cancelled) return;
+        if (!Array.isArray(data)) {
+          setStatus((s) => (s === "ready" ? s : "error"));
+          return;
+        }
+        const slim = data.map((r) => ({
+          tag_name: r.tag_name,
+          name: r.name,
+          published_at: r.published_at,
+          html_url: r.html_url,
+          body: r.body,
+        }));
+        setRaw(slim);
+        setStatus("ready");
+        writeCache(slim);
+      })
+      .catch(() => {
+        if (!cancelled) setStatus((s) => (s === "ready" ? s : "error"));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { entries: raw ? toEntries(raw) : [], status };
+}

--- a/apps/landing/src/changelog/page.tsx
+++ b/apps/landing/src/changelog/page.tsx
@@ -1,0 +1,108 @@
+import { RELEASES, useChangelog } from "../changelog";
+import type { ChangelogEntry } from "../changelog";
+import { SiteFooter, SiteHeader } from "../chrome";
+import { useHead } from "../head";
+
+const eyebrow = "font-mono text-[12.5px] tracking-[0.16em] uppercase text-accent mb-3.5";
+
+const fmtDate = (iso: string | null) =>
+  iso
+    ? new Intl.DateTimeFormat("en-US", { year: "numeric", month: "long", day: "numeric" }).format(
+        new Date(iso),
+      )
+    : "";
+
+function Entry({ entry }: { entry: ChangelogEntry }) {
+  return (
+    <article className="border-t border-rule-soft py-11 first:border-t-0 first:pt-0">
+      <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+        <h2 className="font-serif text-[2rem] font-medium tracking-[-0.02em]">{entry.version}</h2>
+        <time className="font-mono text-[13px] text-ink-faint">{fmtDate(entry.date)}</time>
+        <a
+          className="ml-auto font-mono text-[12.5px] text-ink-soft underline underline-offset-2 hover:text-accent"
+          href={entry.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View on GitHub ↗
+        </a>
+      </div>
+      {entry.sections.map((section) => (
+        <div className="mt-6" key={section.title}>
+          <h3 className="mb-2.5 font-mono text-[11.5px] tracking-[0.13em] uppercase text-accent">
+            {section.title}
+          </h3>
+          <ul className="flex flex-col gap-2">
+            {section.items.map((item) => (
+              <li
+                className="text-[1.02rem] leading-[1.5] text-ink-soft text-pretty"
+                key={item.commit?.hash ?? item.text}
+              >
+                {item.scope && <span className="font-semibold text-ink">{item.scope}: </span>}
+                {item.text}
+                {item.commit && (
+                  <>
+                    {" "}
+                    <a
+                      className="font-mono text-[12px] text-ink-faint underline underline-offset-2 hover:text-accent"
+                      href={item.commit.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {item.commit.hash}
+                    </a>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </article>
+  );
+}
+
+export function ChangelogPage() {
+  useHead("Changelog — Noteside", "https://noteside.app/changelog");
+  const { entries, status } = useChangelog();
+  return (
+    <>
+      <SiteHeader />
+      <main className="wrap min-h-[60vh] pt-[72px] pb-24 max-sm:pt-12">
+        <div className="mb-12 text-center">
+          <p className={eyebrow}>Changelog</p>
+          <h1 className="font-serif text-[clamp(2.2rem,5vw,3.2rem)] font-medium leading-[1.08] tracking-[-0.02em] text-balance">
+            What's new in Noteside
+          </h1>
+        </div>
+
+        {status === "loading" && (
+          <p className="py-16 text-center font-mono text-[13px] text-ink-faint">
+            Loading releases…
+          </p>
+        )}
+        {status === "error" && (
+          <p className="py-16 text-center font-mono text-[13px] text-ink-faint">
+            Couldn't load releases.{" "}
+            <a
+              className="underline underline-offset-2 hover:text-accent"
+              href={RELEASES}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View them on GitHub ↗
+            </a>
+          </p>
+        )}
+        {status === "ready" && (
+          <div className="mx-auto max-w-[52rem]">
+            {entries.map((entry) => (
+              <Entry entry={entry} key={entry.version} />
+            ))}
+          </div>
+        )}
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/apps/landing/src/chrome.tsx
+++ b/apps/landing/src/chrome.tsx
@@ -1,0 +1,132 @@
+// Shared site chrome (header + footer) used by every landing page (home +
+// changelog). In-page section links are absolute `/#…` so they work from any
+// page — from /changelog they navigate home and scroll.
+import { Link } from "@tanstack/react-router";
+import { GITHUB, RELEASES } from "./downloads";
+import { Wordmark } from "./logo";
+
+// The docs site (docs.noteside.app in prod). Override with VITE_DOCS_URL.
+export const DOCS = import.meta.env.VITE_DOCS_URL ?? "https://docs.noteside.app";
+const AUTHOR = "https://github.com/joshxfi";
+
+export function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-20 border-b border-rule-soft bg-paper/88 backdrop-blur-[10px]">
+      <div className="wrap flex h-[62px] items-center gap-[22px]">
+        <Link
+          className="inline-block whitespace-nowrap font-serif text-[22px] font-semibold tracking-[-0.01em]"
+          to="/"
+        >
+          <Wordmark />
+        </Link>
+        <nav className="ml-3.5 flex gap-[22px] font-mono text-[13px] text-ink-soft max-sm:hidden">
+          <Link className="whitespace-nowrap hover:text-ink" to="/changelog">
+            Changelog
+          </Link>
+          <a className="whitespace-nowrap hover:text-ink" href={DOCS}>
+            Docs
+          </a>
+          <a
+            className="whitespace-nowrap hover:text-ink"
+            href={GITHUB}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub ↗
+          </a>
+        </nav>
+        <div className="ml-auto flex items-center gap-3">
+          <a className="btn btn-ghost" href={DOCS}>
+            Documentation
+          </a>
+          <a className="btn btn-primary" href="/#get">
+            Get started
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-rule-soft bg-paper-2 pt-[54px] pb-[60px]">
+      <div className="wrap">
+        <div className="flex flex-wrap items-start justify-between gap-7">
+          <div className="flex flex-col gap-1 font-serif text-2xl font-semibold">
+            <Wordmark />
+            <span className="font-mono text-[11px] font-normal tracking-[0.03em] text-ink-faint">
+              notes for keyboard people
+            </span>
+          </div>
+          <div className="flex gap-[30px] font-mono text-[13px] text-ink-soft">
+            <div className="flex flex-col gap-2.5">
+              <span className="text-[11px] tracking-[0.12em] uppercase whitespace-nowrap text-ink-faint">
+                Product
+              </span>
+              <a className="whitespace-nowrap hover:text-accent" href={DOCS}>
+                Documentation
+              </a>
+              <a className="whitespace-nowrap hover:text-accent" href="/#get">
+                Get started
+              </a>
+              <Link className="whitespace-nowrap hover:text-accent" to="/changelog">
+                Changelog
+              </Link>
+              <a className="whitespace-nowrap hover:text-accent max-sm:hidden" href="/#demo">
+                Live demo
+              </a>
+              <a className="whitespace-nowrap hover:text-accent" href="/#features">
+                Features
+              </a>
+            </div>
+            <div className="flex flex-col gap-2.5">
+              <span className="text-[11px] tracking-[0.12em] uppercase whitespace-nowrap text-ink-faint">
+                Open source
+              </span>
+              <a
+                className="whitespace-nowrap hover:text-accent"
+                href={GITHUB}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub
+              </a>
+              <a
+                className="whitespace-nowrap hover:text-accent"
+                href={RELEASES}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Releases
+              </a>
+              <a
+                className="whitespace-nowrap hover:text-accent"
+                href={`${GITHUB}/issues`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Issues
+              </a>
+            </div>
+          </div>
+        </div>
+        <div className="mt-[30px] flex w-full flex-wrap justify-between gap-4 border-t border-rule-soft pt-[22px] font-mono text-[12px] text-ink-faint">
+          <span>
+            Free forever. Open source. Built by{" "}
+            <a
+              className="text-ink-soft hover:text-accent"
+              href={AUTHOR}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Josh Daniel
+            </a>
+            .
+          </span>
+          <span>~/.notesiderc</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/landing/src/head.ts
+++ b/apps/landing/src/head.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+// Per-route <title> + canonical, set client-side. The landing is a client SPA
+// (no prerender), so route-specific SEO lives here rather than in a static
+// <head>. Updates the existing canonical <link> in place (no duplicate tags).
+export function useHead(title: string, canonical: string) {
+  useEffect(() => {
+    document.title = title;
+    let link = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    if (!link) {
+      link = document.createElement("link");
+      link.rel = "canonical";
+      document.head.appendChild(link);
+    }
+    link.href = canonical;
+  }, [title, canonical]);
+}

--- a/apps/landing/src/main.tsx
+++ b/apps/landing/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./app";
+import { RouterProvider } from "@tanstack/react-router";
+import { router } from "./router";
 import "./styles.css";
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
 );

--- a/apps/landing/src/router.tsx
+++ b/apps/landing/src/router.tsx
@@ -1,0 +1,28 @@
+import { createRootRoute, createRoute, createRouter, Outlet } from "@tanstack/react-router";
+import { App } from "./app";
+import { ChangelogPage } from "./changelog/page";
+
+// Each page renders its own <SiteHeader/>/<SiteFooter/>, so the root is just the
+// outlet for the matched route.
+function RootLayout() {
+  return <Outlet />;
+}
+
+const rootRoute = createRootRoute({ component: RootLayout });
+
+const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: "/", component: App });
+const changelogRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/changelog",
+  component: ChangelogPage,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, changelogRoute]);
+
+export const router = createRouter({ routeTree, scrollRestoration: true });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,13 +156,13 @@ importers:
         version: 7.17.0(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
       fumadocs-core:
         specifier: 16.10.3
-        version: 16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.0.12
-        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
       fumadocs-ui:
         specifier: 16.10.3
-        version: 16.10.3(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)
+        version: 16.10.3(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)
       isbot:
         specifier: ^5.1.42
         version: 5.1.43
@@ -218,6 +218,9 @@ importers:
 
   apps/landing:
     dependencies:
+      '@tanstack/react-router':
+        specifier: 1.170.16
+        version: 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -1953,6 +1956,10 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.7'
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/react-devtools@0.9.13':
     resolution: {integrity: sha512-O9YXTEe2dlnw2pPNKFZ4Wk7zC4qrDvc0SAALKfMVedeZ2Dyd0LEJUabYS6GPm+DmnrBhc7nJx6Zqc9aDjFrj4g==}
     engines: {node: '>=18'}
@@ -1962,11 +1969,31 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-router@1.170.16':
+    resolution: {integrity: sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/react-virtual@3.14.2':
     resolution: {integrity: sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.13':
+    resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@tanstack/virtual-core@3.17.0':
     resolution: {integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==}
@@ -2394,6 +2421,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -3776,6 +3806,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -5461,6 +5496,8 @@ snapshots:
       - csstype
       - utf-8-validate
 
+  '@tanstack/history@1.162.0': {}
+
   '@tanstack/react-devtools@0.9.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)':
     dependencies:
       '@tanstack/devtools': 0.10.14(csstype@3.2.3)(solid-js@1.9.13)
@@ -5474,11 +5511,36 @@ snapshots:
       - solid-js
       - utf-8-validate
 
+  '@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-core': 1.171.13
+      isbot: 5.1.43
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
   '@tanstack/react-virtual@3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tanstack/virtual-core': 3.17.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/router-core@1.171.13':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
 
   '@tanstack/virtual-core@3.17.0': {}
 
@@ -5870,6 +5932,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   cookie@1.1.1: {}
 
   crelt@1.0.6: {}
@@ -6130,7 +6194,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -6151,6 +6215,7 @@ snapshots:
       vfile: 6.0.3
     optionalDependencies:
       '@mdx-js/mdx': 3.1.1
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -6163,14 +6228,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       js-yaml: 4.2.0
       mdast-util-mdx: 3.0.0
       picocolors: 1.1.1
@@ -6192,7 +6257,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.10.3(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1):
+  fumadocs-ui@16.10.3(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.1)(tailwindcss@4.3.1)
@@ -6207,7 +6272,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-tabs': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.10.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.18.0(react@19.2.7)
       motion: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7650,6 +7715,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   uuid@8.3.2: {}
 

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm build:landing",
   "outputDirectory": "apps/landing/dist",
-  "framework": null
+  "framework": null,
+  "rewrites": [{ "source": "/((?!assets/|demo/|.*\\.).*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## What

Adds a **`/changelog`** page to the marketing site listing each release's changes, and introduces client-side routing to the landing.

## Source — live GitHub Releases

Fetches the GitHub Releases API at runtime, reusing `downloads.ts`'s fetch + `sessionStorage`-cache + graceful-fallback pattern. Always current, independent of landing deploys — the release commit is tagged `[skip ci]`, so Vercel wouldn't rebuild the landing on a release, which would make a build-time `CHANGELOG.md` lag. A pure `parseReleaseBody()` turns semantic-release's notes into sections; **no markdown-renderer dependency**.

## Routing

The landing had no router, so this adds **TanStack Router** (routes `/` and `/changelog`) + a Vercel SPA rewrite for the clean `/changelog` URL. Header/footer are extracted into shared `SiteHeader`/`SiteFooter` with a "Changelog" link; the logo + Changelog use `<Link>` for client-side nav. Per-route `<title>`/canonical are set via a small `useHead` hook (updates the existing tags — no duplicates).

## Also

- v1.0.0 (the initial full feature-dump release) is filtered out via `HIDDEN_TAGS` in `changelog.ts`.
- Header nav trimmed to **Changelog · Docs · GitHub**.

## Verified

`tsc` · `oxlint` · `oxfmt` · `vite build`, plus a browser check: direct `/changelog` load renders v1.2.0 + v1.1.0 with sections + commit links; client-side nav between `/` and `/changelog` with no reload; title/canonical update per route.

## Note (follow-up)

`/changelog`'s SEO meta is set client-side only — the landing isn't prerendered, so it's not in the raw HTML (fine for a changelog; Google executes JS). Making it prerendered would mean adding SSG (e.g. `vite-react-ssg` / TanStack Start) — a separate change.
