### PR TITLE
Audit fixes: correctness, JS↔Rust parity, durability/perf, and delete-op tests

### DIFF
--- a/apps/desktop/e2e/delete.spec.ts
+++ b/apps/desktop/e2e/delete.spec.ts
@@ -1,0 +1,24 @@
+import { boot, expect, test } from "./fixtures";
+
+test.describe("delete note", () => {
+  test(":rm deletes the active note, confirms, and opens another", async ({ page }) => {
+    await boot(page, { vimMode: true });
+    await page.locator(".cm-content").click();
+
+    const activeTitle = await page.locator(".av-item.is-active .av-item-titletext").innerText();
+    const before = await page.locator(".av-item").count();
+    expect(before).toBeGreaterThan(1); // the demo seeds several notes
+
+    // Delete via the :rm ex-command (→ the "delete" command → deleteActive).
+    await page.keyboard.press(":");
+    await page.keyboard.type("rm");
+    await page.keyboard.press("Enter");
+
+    // The toast confirms, the row is gone, the sidebar shrank by one, and a
+    // different note is now active.
+    await expect(page.locator(".av-toast")).toContainText("note deleted");
+    await expect(page.locator(".av-item").filter({ hasText: activeTitle })).toHaveCount(0);
+    await expect(page.locator(".av-item")).toHaveCount(before - 1);
+    await expect(page.locator(".av-item.is-active")).not.toContainText(activeTitle);
+  });
+});

--- a/apps/desktop/src-tauri/src/frecency.rs
+++ b/apps/desktop/src-tauri/src/frecency.rs
@@ -31,7 +31,10 @@ impl FrecencyEntry {
     /// running backwards — skew must decay-to-nothing, never inflate.
     pub fn effective(&self, now_ms: u64) -> f64 {
         let elapsed = now_ms.saturating_sub(self.last_ms) as f64;
-        self.score * 0.5f64.powf(elapsed / HALF_LIFE_MS as f64)
+        // Clamp to >= 0: the empty-query finder sorts on `to_bits()`, where a
+        // negative f64 (only reachable via a corrupt/hand-edited frecency.json)
+        // would sort as the largest u64 and wrongly rank first.
+        (self.score * 0.5f64.powf(elapsed / HALF_LIFE_MS as f64)).max(0.0)
     }
 
     /// Record an open: decay the running score to `now_ms`, then add 1.
@@ -65,11 +68,10 @@ pub fn load(file: &Path, root: &str) -> HashMap<String, FrecencyEntry> {
 pub fn save(file: &Path, root: &str, map: &HashMap<String, FrecencyEntry>, now_ms: u64) {
     let mut store = read_store(file);
     store.insert(root.to_string(), prune(map, now_ms));
-    if let Some(dir) = file.parent() {
-        let _ = fs::create_dir_all(dir);
-    }
     if let Ok(json) = serde_json::to_string(&store) {
-        let _ = fs::write(file, json);
+        // Crash-safe (temp + rename), so a mid-write crash never leaves the
+        // shared multi-notebook file torn. Best-effort: errors are ignored.
+        let _ = crate::notebook::atomic_write(file, &json);
     }
 }
 
@@ -154,6 +156,46 @@ mod tests {
 
         fs::write(&file, "not json").unwrap();
         assert!(load(&file, "/nb1").is_empty()); // corrupt file → empty map
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn effective_clamps_a_corrupt_negative_score_to_zero() {
+        // Only reachable from a hand-edited/corrupt frecency.json; must not sort
+        // ahead of real entries via to_bits().
+        let e = FrecencyEntry {
+            score: -5.0,
+            last_ms: 0,
+        };
+        assert_eq!(e.effective(0), 0.0);
+        assert_eq!(e.effective(HALF_LIFE_MS), 0.0);
+    }
+
+    #[test]
+    fn save_writes_atomically_leaving_no_temp_file() {
+        let dir =
+            std::env::temp_dir().join(format!("noteside-frecency-atomic-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let file = dir.join("frecency.json");
+
+        let mut map = HashMap::new();
+        map.insert(
+            "a.md".to_string(),
+            FrecencyEntry {
+                score: 1.0,
+                last_ms: 0,
+            },
+        );
+        save(&file, "/nb", &map, 0);
+        assert_eq!(load(&file, "/nb"), map); // content round-trips
+
+        // The temp+rename must not leave a sibling temp file behind.
+        let leftover = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".tmp"));
+        assert!(!leftover, "atomic write left a temp file behind");
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/apps/desktop/src-tauri/src/links.rs
+++ b/apps/desktop/src-tauri/src/links.rs
@@ -16,10 +16,16 @@ fn parse_targets(line: &str) -> Vec<&str> {
         match line[start..].find("]]") {
             Some(close) => {
                 let inner = &line[start..start + close];
-                // brackets/pipes/newlines aren't allowed in a target (mirror the TS regex)
-                if !inner.is_empty() && !inner.contains('[') {
-                    let target = inner.split('|').next().unwrap_or("").trim();
-                    if !target.is_empty() {
+                // Mirror the TS WIKILINK regex: target/display may not contain
+                // '[' ']' '|'; at most one '|' (target|display), and a present
+                // display must be non-empty.
+                if !inner.is_empty() && !inner.contains('[') && !inner.contains(']') {
+                    let mut parts = inner.split('|');
+                    let target = parts.next().unwrap_or("").trim();
+                    let display = parts.next();
+                    let extra_pipe = parts.next().is_some();
+                    let display_ok = display.map_or(true, |d| !d.is_empty());
+                    if !target.is_empty() && !extra_pipe && display_ok {
                         out.push(target);
                     }
                 }
@@ -193,6 +199,26 @@ mod tests {
             vec!["A", "b c"]
         );
         assert!(parse_targets("[[]] and [[unterminated").is_empty());
+    }
+
+    #[test]
+    fn wikilink_parity_matches_shared_vectors() {
+        let raw = include_str!("../../src/test-vectors/parity.json");
+        let v: serde_json::Value = serde_json::from_str(raw).unwrap();
+        for case in v["wikilinkTargets"].as_array().unwrap() {
+            let line = case["line"].as_str().unwrap();
+            let expected: Vec<&str> = case["out"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_str().unwrap())
+                .collect();
+            assert_eq!(
+                parse_targets(line),
+                expected,
+                "wikilink parity for {line:?}"
+            );
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/notebook.rs
+++ b/apps/desktop/src-tauri/src/notebook.rs
@@ -241,17 +241,20 @@ pub fn atomic_write(abs: &Path, text: &str) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Build a filesystem-safe slug from a title.
+/// Build a filesystem-safe slug from a title. ASCII-only: mirrors `links::slug`
+/// and the JS `slugifyTitle` byte-for-byte (so the rename pre-check and wikilink
+/// resolution agree — see src/test-vectors/parity.json). Non-ASCII and
+/// punctuation collapse to a single '-'; falls back to "untitled".
 pub fn slugify(title: &str) -> String {
     let mut out = String::new();
-    let mut prev_dash = false;
-    for ch in title.trim().chars() {
-        if ch.is_alphanumeric() {
-            out.extend(ch.to_lowercase());
-            prev_dash = false;
-        } else if !prev_dash && !out.is_empty() {
+    let mut in_dash = false;
+    for ch in title.trim().to_lowercase().chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            in_dash = false;
+        } else if !in_dash {
             out.push('-');
-            prev_dash = true;
+            in_dash = true;
         }
     }
     let slug = out.trim_matches('-').to_string();
@@ -322,6 +325,17 @@ mod tests {
         assert_eq!(slugify("  Spaces  & punctuation!! "), "spaces-punctuation");
         assert_eq!(slugify(""), "untitled");
         assert_eq!(slugify("---"), "untitled");
+    }
+
+    #[test]
+    fn slug_parity_matches_shared_vectors() {
+        let raw = include_str!("../../src/test-vectors/parity.json");
+        let v: serde_json::Value = serde_json::from_str(raw).unwrap();
+        for case in v["slug"].as_array().unwrap() {
+            let input = case["in"].as_str().unwrap();
+            let expected = case["out"].as_str().unwrap();
+            assert_eq!(slugify(input), expected, "slug parity for {input:?}");
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/search.rs
+++ b/apps/desktop/src-tauri/src/search.rs
@@ -379,29 +379,34 @@ fn ci_ranges(line: &str, needle_lc: &str) -> Vec<[u32; 2]> {
         return Vec::new();
     }
     let mut low = String::with_capacity(line.len());
-    // For each byte of `low`, the byte offset in `line` of the source char that
-    // produced it; a trailing sentinel maps `low.len()` to `line.len()`.
-    let mut origin: Vec<usize> = Vec::with_capacity(line.len() + 1);
+    // Per low byte: the START and END byte offsets in `line` of the source char
+    // that produced it. Using the END for a match's last byte lets a match that
+    // ends mid-expansion (e.g. the "i" of 'İ' → "i̇") still cover the whole char.
+    let mut start_of: Vec<usize> = Vec::with_capacity(line.len() + 1);
+    let mut end_of: Vec<usize> = Vec::with_capacity(line.len() + 1);
     for (obi, ch) in line.char_indices() {
+        let end = obi + ch.len_utf8();
         for lc in ch.to_lowercase() {
             let mut buf = [0u8; 4];
             let s = lc.encode_utf8(&mut buf);
             for _ in 0..s.len() {
-                origin.push(obi);
+                start_of.push(obi);
+                end_of.push(end);
             }
             low.push_str(s);
         }
     }
-    origin.push(line.len());
+    start_of.push(line.len());
+    end_of.push(line.len());
 
     let mut ranges = Vec::new();
     let mut from = 0;
     while let Some(off) = low[from..].find(needle_lc) {
         let ls = from + off;
         let le = ls + needle_lc.len();
-        // ls/le are char boundaries of `low` (both strings are valid UTF-8), so
-        // `origin[ls]`/`origin[le]` are defined (sentinel covers le == low.len()).
-        ranges.push([origin[ls] as u32, origin[le] as u32]);
+        // Cover whole source chars: start at the char holding the first matched
+        // low byte, end at the char holding the last matched low byte (le-1).
+        ranges.push([start_of[ls] as u32, end_of[le - 1] as u32]);
         from = le;
     }
     ranges
@@ -591,6 +596,19 @@ mod tests {
         }
         let [s, e] = hits[0].ranges[0];
         assert_eq!(&hits[0].line[s as usize..e as usize], "ẞ"); // covers the source char
+    }
+
+    #[test]
+    fn content_plain_nonascii_ranges_cover_whole_char_for_multicodepoint_folds() {
+        // 'İ' (U+0130) lowercases to TWO codepoints ("i" + combining dot); a
+        // needle matching only the "i" prefix must still highlight the whole 'İ',
+        // not collapse to a zero-width range.
+        let recs = vec![rec("a.md", "İstanbul", false, 0)];
+        let hits = content_search(&recs, "i", "plain", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        let [s, e] = hits[0].ranges[0];
+        assert!(e > s, "range must not be zero-width, got [{s},{e}]");
+        assert_eq!(&hits[0].line[s as usize..e as usize], "İ");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/search.rs
+++ b/apps/desktop/src-tauri/src/search.rs
@@ -367,8 +367,44 @@ fn plain_ranges(line: &str, needle: &str, needle_lc: &str, smart_case: bool) -> 
     if line.is_ascii() && needle_lc.is_ascii() {
         return ascii_case_insensitive_ranges(line, needle_lc);
     }
-    let hay = line.to_lowercase();
-    exact_ranges(&hay, needle_lc)
+    ci_ranges(line, needle_lc)
+}
+
+/// Case-insensitive plain-substring ranges whose byte offsets index the
+/// ORIGINAL `line` (never a lowercased copy, which can shift byte lengths for
+/// chars like 'İ'/'ẞ'). Builds the lowercased haystack alongside a byte→origin
+/// map, finds `needle_lc` in it, and translates each match back to `line`.
+fn ci_ranges(line: &str, needle_lc: &str) -> Vec<[u32; 2]> {
+    if needle_lc.is_empty() {
+        return Vec::new();
+    }
+    let mut low = String::with_capacity(line.len());
+    // For each byte of `low`, the byte offset in `line` of the source char that
+    // produced it; a trailing sentinel maps `low.len()` to `line.len()`.
+    let mut origin: Vec<usize> = Vec::with_capacity(line.len() + 1);
+    for (obi, ch) in line.char_indices() {
+        for lc in ch.to_lowercase() {
+            let mut buf = [0u8; 4];
+            let s = lc.encode_utf8(&mut buf);
+            for _ in 0..s.len() {
+                origin.push(obi);
+            }
+            low.push_str(s);
+        }
+    }
+    origin.push(line.len());
+
+    let mut ranges = Vec::new();
+    let mut from = 0;
+    while let Some(off) = low[from..].find(needle_lc) {
+        let ls = from + off;
+        let le = ls + needle_lc.len();
+        // ls/le are char boundaries of `low` (both strings are valid UTF-8), so
+        // `origin[ls]`/`origin[le]` are defined (sentinel covers le == low.len()).
+        ranges.push([origin[ls] as u32, origin[le] as u32]);
+        from = le;
+    }
+    ranges
 }
 
 fn exact_ranges(line: &str, needle: &str) -> Vec<[u32; 2]> {
@@ -536,6 +572,25 @@ mod tests {
         assert_eq!(hits[0].line_number, 1);
         let [s, e] = hits[0].ranges[0];
         assert_eq!(&hits[0].line[s as usize..e as usize], "Kettle");
+    }
+
+    #[test]
+    fn content_plain_nonascii_ranges_stay_valid_on_the_original_line() {
+        // 'ẞ' (U+1E9E, 3 bytes) lowercases to 'ß' (2 bytes): searching a shorter
+        // lowercased copy shifted offsets so they could land mid-char in `line`.
+        let recs = vec![rec("a.md", "xẞy", false, 0)];
+        let hits = content_search(&recs, "ß", "plain", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        for [s, e] in hits[0].ranges.iter().copied() {
+            // Offsets must be valid char-boundary slices of the SHIPPED line.
+            assert!(
+                hits[0].line.get(s as usize..e as usize).is_some(),
+                "range [{s},{e}] is not a valid slice of {:?}",
+                hits[0].line
+            );
+        }
+        let [s, e] = hits[0].ranges[0];
+        assert_eq!(&hits[0].line[s as usize..e as usize], "ẞ"); // covers the source char
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -118,7 +118,29 @@ pub fn start_watcher(
         Duration::from_millis(400),
         None,
         move |result: DebounceEventResult| {
-            let Ok(events) = result else { return };
+            let events = match result {
+                Ok(events) => events,
+                // A backend error (notably event-queue overflow) means we may have
+                // missed changes — fall back to a full rescan, exactly like an
+                // ambiguous batch. No paths are available here, so skip the .md
+                // prefilter and the echo-suppression check and rescan wholesale.
+                Err(_) => {
+                    let r = {
+                        let Ok(g) = notebook.lock() else { return };
+                        let Some(r) = g.root.clone() else { return };
+                        r
+                    };
+                    let records = notebook::scan_notebook(&r);
+                    let Ok(mut g) = notebook.lock() else { return };
+                    if g.root.as_ref() != Some(&r) {
+                        return; // notebook switched while the rescan was running
+                    }
+                    g.set_records(records);
+                    drop(g);
+                    let _ = app.emit("notebook:changed", ());
+                    return;
+                }
+            };
             let touches_md = events.iter().any(|e| {
                 e.paths
                     .iter()

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -431,6 +431,7 @@ export function App() {
   const [cheatsheetOpen, setCheatsheetOpen] = useState(false);
   const [refocus, setRefocus] = useState(0);
   const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<number | null>(null);
   const [backlinks, setBacklinks] = useState<{ title: string; refs: Backlink[] } | null>(null);
   // first-launch vim / plain-keyboard choice; cleared (and persisted) once picked
   const [onboarding, setOnboarding] = useState(false);
@@ -438,9 +439,20 @@ export function App() {
   const configLoaded = useRef(false);
 
   const flash = useCallback((msg: string) => {
+    if (toastTimer.current !== null) window.clearTimeout(toastTimer.current);
     setToast(msg);
-    setTimeout(() => setToast((m) => (m === msg ? null : m)), 1600);
+    toastTimer.current = window.setTimeout(() => {
+      toastTimer.current = null;
+      setToast(null);
+    }, 1600);
   }, []);
+
+  useEffect(
+    () => () => {
+      if (toastTimer.current !== null) window.clearTimeout(toastTimer.current);
+    },
+    [],
+  );
 
   // The editing session owns the whole per-buffer loop: working/saved/dirty,
   // autosave, open/save/quit, the config buffer kind, external reconcile, and the

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -458,23 +458,15 @@ export function App() {
     onNotesChanged: (list) => setNotes((prev) => (sameMetaList(prev, list) ? prev : list)),
   });
 
-  // apply config -> design tokens. Keyed on the visual fields only, so editing
-  // e.g. the esc-map text field doesn't rewrite every CSS var per keystroke.
+  // Apply the theme: data-theme + inline palette vars + the boot-theme mirror.
+  // Keyed on cfg.theme ONLY, so font/scale key-repeat doesn't recompute the
+  // palette or re-write localStorage (see the debounced persist below).
   useEffect(() => {
     const r = document.documentElement;
     const theme = themeById(cfg.theme);
     if (r.getAttribute("data-theme") !== theme.mode) r.setAttribute("data-theme", theme.mode);
-    // Writes the theme's primitives inline (base16), or clears them so the
-    // [data-theme] block renders verbatim (builtin Noteside light/dark).
     applyThemeVars(r, theme);
-    r.style.setProperty("--editor-font", fontStack(cfg.editorFont, "editor"));
-    r.style.setProperty("--mono", fontStack(cfg.uiFont, "ui"));
-    r.style.setProperty("--editor-size", cfg.fontSize + "px");
-    r.style.setProperty("--editor-lh", String(cfg.lineHeight));
-    r.style.setProperty("--ui-scale", String(cfg.uiScale));
     try {
-      // Mirror for the index.html boot script + bootConfig(): the next launch
-      // paints this theme before the config store loads.
       localStorage.setItem(
         BOOT_THEME_KEY,
         JSON.stringify({ id: theme.id, mode: theme.mode, vars: resolveThemeVars(theme) }),
@@ -482,7 +474,18 @@ export function App() {
     } catch {
       /* private mode / quota — cosmetic only */
     }
-  }, [cfg.theme, cfg.editorFont, cfg.uiFont, cfg.fontSize, cfg.lineHeight, cfg.uiScale]);
+  }, [cfg.theme]);
+
+  // Apply font/size/scale CSS vars. These change on every zoom key-repeat, so
+  // they must NOT drag the palette recompute or the localStorage write along.
+  useEffect(() => {
+    const r = document.documentElement;
+    r.style.setProperty("--editor-font", fontStack(cfg.editorFont, "editor"));
+    r.style.setProperty("--mono", fontStack(cfg.uiFont, "ui"));
+    r.style.setProperty("--editor-size", cfg.fontSize + "px");
+    r.style.setProperty("--editor-lh", String(cfg.lineHeight));
+    r.style.setProperty("--ui-scale", String(cfg.uiScale));
+  }, [cfg.editorFont, cfg.uiFont, cfg.fontSize, cfg.lineHeight, cfg.uiScale]);
 
   // persist config, debounced: held settings steppers fire per key-repeat, and
   // each store.set is an IPC (a sync localStorage write in the demo). The tail

--- a/apps/desktop/src/backend/mock.test.ts
+++ b/apps/desktop/src/backend/mock.test.ts
@@ -72,4 +72,16 @@ describe("mock backend", () => {
     await expect(mockBackend.readNote("journal/old-name.md")).rejects.toThrow();
     expect((await mockBackend.readNote("journal/fresh-title.md")).body).toContain("Fresh Title");
   });
+
+  it("deleteNote removes the note from listing and search", async () => {
+    const a = await mockBackend.createNote("Alpha To Delete");
+    await mockBackend.recordOpen(a.path); // give it frecency so it'd rank in recents
+    expect((await mockBackend.searchFiles("")).some((h) => h.path === a.path)).toBe(true);
+
+    await mockBackend.deleteNote(a.path);
+
+    expect((await mockBackend.listNotes()).some((n) => n.path === a.path)).toBe(false);
+    expect((await mockBackend.searchFiles("")).some((h) => h.path === a.path)).toBe(false);
+    expect((await mockBackend.searchFiles("Alpha")).some((h) => h.path === a.path)).toBe(false);
+  });
 });

--- a/apps/desktop/src/editing-session.test.ts
+++ b/apps/desktop/src/editing-session.test.ts
@@ -269,6 +269,72 @@ describe("editingSession", () => {
     expect(s.savedText).toBe("B");
   });
 
+  it("reconcile() ignores a stale read superseded by a newer reconcile", async () => {
+    const bodies = new Map<string, string>([["a.md", "v1"]]);
+    let readDelay = 0;
+    const meta = (id: string): NoteMeta => ({
+      id,
+      path: id,
+      title: id.replace(/\.md$/, ""),
+      tags: [],
+      created: null,
+      updated: 0,
+      pinned: false,
+    });
+    const backend: Pick<
+      Backend,
+      "readNote" | "saveNote" | "renameNote" | "listNotes" | "recordOpen"
+    > = {
+      async recordOpen() {},
+      async listNotes() {
+        return [...bodies.keys()].map(meta);
+      },
+      async saveNote(id, body) {
+        bodies.set(id, body);
+        return meta(id);
+      },
+      async renameNote(id) {
+        return meta(id);
+      },
+      async readNote(id) {
+        const snapshot = bodies.get(id); // captured at DISPATCH time
+        const d = readDelay;
+        if (d > 0) await new Promise<void>((r) => setTimeout(r, d));
+        if (snapshot === undefined) throw new Error("not found");
+        return { ...meta(id), body: snapshot };
+      },
+    };
+    const notices: string[] = [];
+    const session = createEditingSession({
+      backend,
+      autosaveMs: 800,
+      notify: (m) => notices.push(m),
+      onConfigApply: () => {},
+      onNoteSaved: () => {},
+      onNoteRenamed: () => {},
+      onNotesChanged: () => {},
+    });
+
+    await session.open("a.md"); // clean on v1
+
+    bodies.set("a.md", "v2");
+    readDelay = 100;
+    const slow = session.reconcile(); // reconcile #1: dispatches a slow read, snapshots v2
+    await vi.advanceTimersByTimeAsync(0); // let #1 pass listNotes and dispatch its read
+
+    bodies.set("a.md", "v3");
+    readDelay = 5;
+    const fast = session.reconcile(); // reconcile #2: dispatches a fast read, snapshots v3
+    await vi.advanceTimersByTimeAsync(5);
+    await fast; // #2 resolves first → applies v3
+    await vi.advanceTimersByTimeAsync(100);
+    await slow; // #1 (stale) resolves last
+
+    const s = session.getSnapshot();
+    expect(s.savedText).toBe("v3"); // NOT regressed to "v2" by the stale read
+    expect(s.initialText).toBe("v3");
+  });
+
   it("C2: editorKey changes when re-opening the SAME note at the SAME line", async () => {
     const { session } = makeSession({ "a.md": "A" });
     await session.open("a.md", 0);

--- a/apps/desktop/src/editing-session.test.ts
+++ b/apps/desktop/src/editing-session.test.ts
@@ -289,6 +289,27 @@ describe("editingSession", () => {
     expect(notices).not.toContain("reloaded from disk");
   });
 
+  it("reconcile() does not reseed a buffer dirtied WHILE its read is in flight", async () => {
+    const delays: Record<string, number> = { "a.md": 50 }; // a.md reads slowly
+    const { session, bodies, notices } = makeSession({ "a.md": "disk v1" }, {}, delays);
+    const openA = session.open("a.md");
+    await vi.advanceTimersByTimeAsync(50);
+    await openA; // on A, clean
+
+    bodies.set("a.md", "disk v2"); // external change → reconcile WOULD reload a clean buffer
+    const rp = session.reconcile(); // listNotes resolves, then parks on readNote("a.md") (50ms)
+    await vi.advanceTimersByTimeAsync(0); // let reconcile pass its pre-read guards and issue the read
+    session.change("my local edit"); // user types DURING the read → dirty
+    await vi.advanceTimersByTimeAsync(60); // the read resolves
+    await rp;
+
+    const s = session.getSnapshot();
+    expect(s.dirty).toBe(true); // still dirty — the buffer was NOT reseeded
+    expect(s.initialText).toBe("disk v1"); // mount seed NOT bumped to "disk v2"
+    expect(s.savedText).toBe("disk v1"); // saved baseline unchanged by the dropped reconcile
+    expect(notices).not.toContain("reloaded from disk");
+  });
+
   it("C5: reconcile() reloads a clean buffer when disk differs and bumps the key", async () => {
     const { session, bodies, notices } = makeSession({ "a.md": "disk v1" });
     await session.open("a.md");

--- a/apps/desktop/src/editing-session.ts
+++ b/apps/desktop/src/editing-session.ts
@@ -339,7 +339,7 @@ export function createEditingSession(deps: EditingSessionDeps): EditingSession {
       // Bail if the user navigated (token) OR the active buffer changed (id) during
       // the read — otherwise a late resolve would seed the wrong buffer with this
       // note's body, and the next keystroke would autosave it into the wrong file.
-      if (token !== loadToken || activeId !== id) return;
+      if (token !== loadToken || activeId !== id || noteDirty) return;
       if (doc.body !== noteSaved) {
         noteInitial = doc.body;
         noteSaved = doc.body;

--- a/apps/desktop/src/editing-session.ts
+++ b/apps/desktop/src/editing-session.ts
@@ -108,6 +108,7 @@ export function createEditingSession(deps: EditingSessionDeps): EditingSession {
   // switched away from. (The mock backend resolves in order; the real IPC backend
   // can resolve out of order.)
   let loadToken = 0;
+  let reconcileSeq = 0; // bumped per reconcile() so an older, slower read can't overwrite a newer one
 
   const listeners = new Set<() => void>();
 
@@ -318,12 +319,14 @@ export function createEditingSession(deps: EditingSessionDeps): EditingSession {
 
   async function reconcile(): Promise<void> {
     const token = loadToken; // reactive: bail if the user navigates mid-scan
+    const myReconcile = ++reconcileSeq; // this call is now the latest reconcile
     let list: NoteMeta[];
     try {
       list = await backend.listNotes();
     } catch {
       return;
     }
+    if (myReconcile !== reconcileSeq) return; // a newer reconcile superseded us
     onNotesChanged(list); // sidebar refresh is independent of the active buffer
     if (token !== loadToken) return; // user navigated during the scan
     if (activeId === null || activeId === CONFIG_ID) return;
@@ -339,7 +342,10 @@ export function createEditingSession(deps: EditingSessionDeps): EditingSession {
       // Bail if the user navigated (token) OR the active buffer changed (id) during
       // the read — otherwise a late resolve would seed the wrong buffer with this
       // note's body, and the next keystroke would autosave it into the wrong file.
-      if (token !== loadToken || activeId !== id || noteDirty) return;
+      // ...and bail if a newer reconcile started: its read is at least as fresh,
+      // so this older/slower read must not overwrite the buffer with staler content.
+      if (token !== loadToken || activeId !== id || noteDirty || myReconcile !== reconcileSeq)
+        return;
       if (doc.body !== noteSaved) {
         noteInitial = doc.body;
         noteSaved = doc.body;

--- a/apps/desktop/src/parity.test.ts
+++ b/apps/desktop/src/parity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseWikilinks, slugifyTitle } from "./links";
+import vectors from "./test-vectors/parity.json";
+
+// Shared golden vectors that MUST produce identical output in the Rust backend
+// (see the #[cfg(test)] parity tests in notebook.rs and links.rs). The JS side
+// is the canonical behavior; if a vector changes here, update both suites.
+describe("JS↔Rust parity vectors", () => {
+  it("slugifyTitle matches the shared slug vectors", () => {
+    for (const { in: input, out } of vectors.slug) {
+      expect(slugifyTitle(input)).toBe(out);
+    }
+  });
+
+  it("parseWikilinks targets match the shared wikilink vectors", () => {
+    for (const { line, out } of vectors.wikilinkTargets) {
+      const targets = parseWikilinks(line)
+        .map((w) => w.target)
+        .filter(Boolean);
+      expect(targets).toEqual(out);
+    }
+  });
+});

--- a/apps/desktop/src/test-vectors/parity.json
+++ b/apps/desktop/src/test-vectors/parity.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Shared JS<->Rust golden vectors. Consumed by src/parity.test.ts (Vitest) and by #[cfg(test)] modules in src-tauri/src/notebook.rs and links.rs. Keep the two languages in sync: any change here must keep BOTH test suites green.",
+  "slug": [
+    { "in": "Hello World", "out": "hello-world" },
+    { "in": "  Spaces  & punctuation!! ", "out": "spaces-punctuation" },
+    { "in": "", "out": "untitled" },
+    { "in": "---", "out": "untitled" },
+    { "in": "already-slugged", "out": "already-slugged" },
+    { "in": "UPPER Case", "out": "upper-case" },
+    { "in": "Café Notes", "out": "caf-notes" },
+    { "in": "naïve—dash", "out": "na-ve-dash" },
+    { "in": "日本語", "out": "untitled" }
+  ],
+  "wikilinkTargets": [
+    { "line": "see [[Alpha]] here", "out": ["Alpha"] },
+    { "line": "[[Beta|B]] and [[Gamma]]", "out": ["Beta", "Gamma"] },
+    { "line": "[[  Spaced Out  ]]", "out": ["Spaced Out"] },
+    { "line": "no links here", "out": [] },
+    { "line": "[[One]] [[Two]]", "out": ["One", "Two"] },
+    { "line": "[[a]b]]", "out": [] },
+    { "line": "[[a|b|c]]", "out": [] },
+    { "line": "[[a|]]", "out": [] }
+  ]
+}


### PR DESCRIPTION
Eight logically-independent fixes from a correctness/quality audit, each on its own commit. All touch the desktop app; every change is self-contained and reviewable in isolation.

## Correctness / data-integrity

- **`reconcile()` re-checks `noteDirty` after its `readNote` resolves** — an external-change reload no longer clobbers characters typed during the async read (the post-read guard checked `token`/`activeId` but not dirtiness). Adds a regression test.
- **Watcher full-rescans on a notify `Err`** (e.g. FSEvents/inotify queue overflow) instead of silently dropping the batch — keeps the in-memory index from going permanently stale after a "you missed events" signal.
- **`content_search` highlight ranges index the shipped line**, not a lowercased copy — fixes byte-offset misalignment on non-ASCII lines where `to_lowercase()` changes length (e.g. `ẞ`→`ß`). Ranges are now always valid char-boundary slices.

## JS↔Rust parity

- **Shared golden-vector fixture (`parity.json`) pins slug + wikilink parsing** across the Rust backend and the TS mock, asserted from both a Vitest test and `cargo test`. Fixes two latent drifts it surfaced: `notebook::slugify` now matches the ASCII rule the other three implementations already used (so the rename pre-check agrees), and `links::parse_targets` now mirrors the JS `WIKILINK` regex (rejects `]`, a second `|`, and an empty display).

## Durability / performance

- **`frecency.json` written atomically** (temp + fsync + rename, reusing `atomic_write`) so a mid-write crash can't tear the shared multi-notebook file; `effective()` clamps a corrupt negative score to `0` so it can't sort first via `to_bits()`.
- **Split the theme/config effect** so font/UI-zoom key-repeat no longer recomputes the base16 palette twice and does a synchronous `localStorage` write per repeat — theme work is now keyed on `cfg.theme` only.
- **`flash()` toast** clears its previous timer (a repeated message no longer gets dismissed early) and cleans up on unmount.

## Tests

- **Note-delete coverage** — the only irreversible op (`remove_file`, no undo) previously had none: adds a mock-backend unit test (gone from listing, recents, and search) and a Playwright e2e (`:rm` → toast → row removed → next note active), passing in chromium + webkit.

## Verification (run on this combined branch)

- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm format:check` ✓
- JS unit: **136 passed** (10 files) · e2e: **28 passed** (chromium + webkit)
- `cargo fmt --check` ✓ · `cargo clippy --all-targets -D warnings` ✓ · `cargo test`: **62 passed**
