### PR TITLE
test: align release-workflow guard with the publish job's --repo fix

### DIFF
--- a/apps/desktop/src/release-workflow.test.ts
+++ b/apps/desktop/src/release-workflow.test.ts
@@ -17,9 +17,13 @@ describe("release publication ordering", () => {
     expect(workflow).toContain("releaseDraft: true");
     expect(workflow).not.toContain("releaseDraft: false");
     expect(workflow).toContain("needs: [release, build]");
-    expect(workflow).toContain('gh release edit "v${VERSION}" --draft=false --latest');
+    // The publish step flips the draft to a public "latest" release. Match the
+    // flag-flip only (not the exact gh invocation) so adding flags like --repo
+    // doesn't break this guard.
+    expect(workflow).toContain("gh release edit");
+    expect(workflow).toContain("--draft=false --latest");
     expect(workflow.indexOf("releaseDraft: true")).toBeLessThan(
-      workflow.indexOf('gh release edit "v${VERSION}" --draft=false --latest'),
+      workflow.indexOf("--draft=false --latest"),
     );
   });
 });


### PR DESCRIPTION
## Context

The v1.5.1 **Release** run failed at the final **Publish** job: v1.5.1 was tagged, a draft release was created, and all four native builds attached their bundles — but the draft→published flip never happened, leaving the release stuck as a draft.

**Root cause:** the `publish` job had no `actions/checkout` step, so `gh release edit "v${VERSION}" --draft=false --latest` couldn't resolve the repo from a git remote and died with `fatal: not a git repository`.

**Fix** (already on `main` as `bd4f852`): pass the repo explicitly so the flag-flip needs no checkout —
```
gh release edit "v${VERSION}" --repo "${{ github.repository }}" --draft=false --latest
```

## This PR

`release-workflow.test.ts` pinned the *exact* old command string, so `bd4f852` turned CI red. This relaxes the guard to assert the intent — a `gh release edit` publish step that flips `--draft=false --latest`, ordered after `releaseDraft: true` — instead of the literal `gh` invocation, so future flag additions (like `--repo`) don't break it.

- ✅ `vitest run release-workflow` passes locally
- Restores `main` to green once merged