### PR TITLE
ci: title releases with the bare tag to match the convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.semantic.outputs.new_release_version }}
           RELEASE_NOTES: ${{ steps.semantic.outputs.new_release_notes }}
-        run: gh release create "v${VERSION}" --draft --title "Noteside v${VERSION}" --notes "${RELEASE_NOTES}"
+        run: gh release create "v${VERSION}" --draft --title "v${VERSION}" --notes "${RELEASE_NOTES}"
 
   build:
     name: Build · ${{ matrix.label }}

--- a/apps/desktop/src/release-workflow.test.ts
+++ b/apps/desktop/src/release-workflow.test.ts
@@ -13,6 +13,13 @@ describe("release publication ordering", () => {
     expect(workflow).toContain('gh release create "v${VERSION}" --draft');
   });
 
+  it("titles the release with the bare tag, matching the historical convention", () => {
+    // Older releases (v1.0.0 … v1.5.0) are titled "vX.Y.Z". Set the title
+    // explicitly rather than relying on tauri-action to overwrite a "Noteside …" name.
+    expect(workflow).toContain('--title "v${VERSION}"');
+    expect(workflow).not.toContain('--title "Noteside');
+  });
+
   it("uploads every matrix artifact to the draft before publishing", () => {
     expect(workflow).toContain("releaseDraft: true");
     expect(workflow).not.toContain("releaseDraft: false");


### PR DESCRIPTION
## Problem

The `Create draft GitHub release` step titles the release `Noteside v${VERSION}`, which is inconsistent with every historical release (v1.0.0 → v1.5.0), all titled just `vX.Y.Z`.

Today the final title happens to come out correct only by accident: `tauri-action` overwrites the draft's name back to the bare tag while attaching binaries. If that side effect ever changes, releases would ship the inconsistent `Noteside vX.Y.Z` title.

## Change

- `release.yml`: set `--title "v${VERSION}"` so the intended title is explicit and matches the convention regardless of tauri-action's behavior.
- `release-workflow.test.ts`: add a guard asserting the workflow titles with the bare tag and never `--title "Noteside …"`, so this can't silently regress.

`vitest run release-workflow` passes (3/3) locally.